### PR TITLE
Skip XSS check in local

### DIFF
--- a/src/Analyzers/Reliability/CachePrefixAnalyzer.php
+++ b/src/Analyzers/Reliability/CachePrefixAnalyzer.php
@@ -38,7 +38,8 @@ class CachePrefixAnalyzer extends ReliabilityAnalyzer
     public function errorMessage()
     {
         return "Your cache prefix is too generic and may result in collisions with other apps "
-            ."that share the same cache servers.";
+            ."that share the same cache servers. In general, this should be fixed if you set "
+            ."a non-generic app name in your .env file.";
     }
 
     /**

--- a/src/Analyzers/Security/XSSAnalyzer.php
+++ b/src/Analyzers/Security/XSSAnalyzer.php
@@ -92,6 +92,6 @@ class XSSAnalyzer extends SecurityAnalyzer
     public function skip()
     {
         // Skip this analyzer if the app is stateless (e.g. API only apps).
-        return $this->appIsStateless();
+        return $this->isLocalAndShouldSkip() || $this->appIsStateless();
     }
 }

--- a/tests/Analyzers/Security/XSSAnalyzerTest.php
+++ b/tests/Analyzers/Security/XSSAnalyzerTest.php
@@ -34,6 +34,20 @@ class XSSAnalyzerTest extends AnalyzerTestCase
     /**
      * @test
      */
+    public function skips_for_local()
+    {
+        $this->app->config->set('app.env', 'local');
+
+        $this->registerStatefulGlobalMiddleware();
+
+        $this->runEnlightn();
+
+        $this->assertSkipped(XSSAnalyzer::class);
+    }
+
+    /**
+     * @test
+     */
     public function detects_missing_csp_header()
     {
         $this->registerStatefulGlobalMiddleware();


### PR DESCRIPTION
CSP headers make sense to be set in production. So skipping it in local seems to be a better idea.