### PR TITLE
Fix analyzer percentage computation

### DIFF
--- a/src/Console/EnlightnCommand.php
+++ b/src/Console/EnlightnCommand.php
@@ -202,7 +202,13 @@ class EnlightnCommand extends Command
         $totalAnalyzersInCategory = (float) collect($this->result[$category])->sum(function ($count) {
             return $count;
         });
-        $percentage = round((float) $this->result[$category][$status] * 100 / $totalAnalyzersInCategory, 0);
+
+        if ($totalAnalyzersInCategory == 0) {
+            // Avoid division by zero.
+            $percentage = 0;
+        } else {
+            $percentage = round((float) $this->result[$category][$status] * 100 / $totalAnalyzersInCategory, 0);
+        }
 
         return $this->result[$category][$status]
             .str_pad(" ({$percentage}%)", 6, " ", STR_PAD_LEFT);

--- a/tests/EnlightnCommandTest.php
+++ b/tests/EnlightnCommandTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Enlightn\Enlightn\Tests;
+
+use Enlightn\Enlightn\Analyzers\Reliability\CachePrefixAnalyzer;
+use Enlightn\Enlightn\Analyzers\Security\AppDebugAnalyzer;
+
+class EnlightnCommandTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function command_exits_with_success_status_code_on_passing()
+    {
+        $this->app->config->set('enlightn.analyzers', AppDebugAnalyzer::class);
+        $this->app->config->set('app.env', 'production');
+        $this->app->config->set('app.debug', false);
+
+        $this->artisan('enlightn')->assertExitCode(0);
+    }
+
+    /**
+     * @test
+     */
+    public function command_exits_with_failure_status_code_on_failing()
+    {
+        $this->app->config->set('enlightn.analyzers', AppDebugAnalyzer::class);
+        $this->app->config->set('app.env', 'production');
+        $this->app->config->set('app.debug', true);
+
+        $this->artisan('enlightn')->assertExitCode(1);
+    }
+
+    /**
+     * @test
+     */
+    public function command_exits_with_success_status_code_if_all_pass()
+    {
+        $this->app->config->set('enlightn.analyzers', [AppDebugAnalyzer::class, CachePrefixAnalyzer::class]);
+        $this->app->config->set('app.env', 'production');
+        $this->app->config->set('app.debug', false);
+        $this->app->config->set('cache.prefix', 'enlightn_cache');
+
+        $this->artisan('enlightn')->assertExitCode(0);
+    }
+
+    /**
+     * @test
+     */
+    public function command_exits_with_failure_status_code_if_any_one_fails()
+    {
+        $this->app->config->set('enlightn.analyzers', [AppDebugAnalyzer::class, CachePrefixAnalyzer::class]);
+        $this->app->config->set('app.env', 'production');
+        $this->app->config->set('app.debug', true);
+        $this->app->config->set('cache.prefix', 'enlightn_cache');
+
+        $this->artisan('enlightn')->assertExitCode(1);
+    }
+}


### PR DESCRIPTION
Fixes a bug, where if the analyzer whitelist doesn't contain analyzers from a certain category, the Enlightn command would blow up because of a division by zero. Also added tests for the Enlightn command to ensure everything's working.