### PR TITLE
Improve detection of HTTPS only apps

### DIFF
--- a/src/Analyzers/Concerns/DetectsHttps.php
+++ b/src/Analyzers/Concerns/DetectsHttps.php
@@ -13,8 +13,8 @@ trait DetectsHttps
      */
     protected function appIsHttpsOnly()
     {
-        // We assume here that if the app URL points includes the https protocol or if the secure attribute
-        // is set as the default for all cookies, then the app is an HTTPS only app.
+        // We assume here that if the app URL points to a URL with the https protocol or if the secure attribute
+        // is set to true (as the default for all app cookies), then the app is an HTTPS only app.
         return Str::contains(config('app.url'), 'https://') || config('session.secure') == true;
     }
 }

--- a/src/Analyzers/Concerns/DetectsHttps.php
+++ b/src/Analyzers/Concerns/DetectsHttps.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Enlightn\Enlightn\Analyzers\Concerns;
+
+use Illuminate\Support\Str;
+
+trait DetectsHttps
+{
+    /**
+     * Determine if the application is an HTTPS only app.
+     *
+     * @return bool
+     */
+    protected function appIsHttpsOnly()
+    {
+        // We assume here that if the app URL points includes the https protocol or if the secure attribute
+        // is set as the default for all cookies, then the app is an HTTPS only app.
+        return Str::contains(config('app.url'), 'https://') || config('session.secure') == true;
+    }
+}

--- a/src/Analyzers/Security/HSTSHeaderAnalyzer.php
+++ b/src/Analyzers/Security/HSTSHeaderAnalyzer.php
@@ -3,6 +3,7 @@
 namespace Enlightn\Enlightn\Analyzers\Security;
 
 use Enlightn\Enlightn\Analyzers\Concerns\AnalyzesHeaders;
+use Enlightn\Enlightn\Analyzers\Concerns\DetectsHttps;
 use GuzzleHttp\Client;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Routing\Router;
@@ -10,7 +11,7 @@ use Enlightn\Enlightn\Analyzers\Concerns\AnalyzesMiddleware;
 
 class HSTSHeaderAnalyzer extends SecurityAnalyzer
 {
-    use AnalyzesMiddleware, AnalyzesHeaders;
+    use AnalyzesMiddleware, AnalyzesHeaders, DetectsHttps;
 
     /**
      * The title describing the analyzer.
@@ -75,11 +76,10 @@ class HSTSHeaderAnalyzer extends SecurityAnalyzer
      * Determine whether to skip the analyzer.
      *
      * @return bool
-     * @throws \ReflectionException
      */
     public function skip()
     {
         // Skip this analyzer if the app is not an HTTPS only application.
-        return config('session.secure') !== true;
+        return ! $this->appIsHttpsOnly();
     }
 }

--- a/tests/Analyzers/Security/HSTSHeaderAnalyzerTest.php
+++ b/tests/Analyzers/Security/HSTSHeaderAnalyzerTest.php
@@ -4,7 +4,6 @@ namespace Enlightn\Enlightn\Tests\Analyzers\Security;
 
 use Enlightn\Enlightn\Analyzers\Security\HSTSHeaderAnalyzer;
 use Enlightn\Enlightn\Tests\Analyzers\AnalyzerTestCase;
-use Enlightn\Enlightn\Tests\Analyzers\Concerns\InteractsWithMiddleware;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
@@ -12,8 +11,6 @@ use Illuminate\Support\Facades\Route;
 
 class HSTSHeaderAnalyzerTest extends AnalyzerTestCase
 {
-    use InteractsWithMiddleware;
-
     protected function getEnvironmentSetUp($app)
     {
         parent::getEnvironmentSetUp($app);
@@ -36,8 +33,6 @@ class HSTSHeaderAnalyzerTest extends AnalyzerTestCase
      */
     public function detects_missing_hsts_header_for_https_url()
     {
-        $this->registerStatefulGlobalMiddleware();
-
         $this->app->config->set('app.url', 'https://localhost');
 
         $this->app->make(HSTSHeaderAnalyzer::class)->setClient(new Client(
@@ -60,8 +55,6 @@ class HSTSHeaderAnalyzerTest extends AnalyzerTestCase
      */
     public function detects_missing_hsts_header_for_secure_cookie_attributes()
     {
-        $this->registerStatefulGlobalMiddleware();
-
         $this->app->config->set('session.secure', true);
 
         $this->app->make(HSTSHeaderAnalyzer::class)->setClient(new Client(
@@ -84,8 +77,6 @@ class HSTSHeaderAnalyzerTest extends AnalyzerTestCase
      */
     public function passes_for_hsts_headers()
     {
-        $this->registerStatefulGlobalMiddleware();
-
         $this->app->config->set('session.secure', true);
         $this->app->config->set('app.url', 'https://localhost');
 

--- a/tests/Analyzers/Security/HSTSHeaderAnalyzerTest.php
+++ b/tests/Analyzers/Security/HSTSHeaderAnalyzerTest.php
@@ -34,7 +34,31 @@ class HSTSHeaderAnalyzerTest extends AnalyzerTestCase
     /**
      * @test
      */
-    public function detects_missing_hsts_header()
+    public function detects_missing_hsts_header_for_https_url()
+    {
+        $this->registerStatefulGlobalMiddleware();
+
+        $this->app->config->set('app.url', 'https://localhost');
+
+        $this->app->make(HSTSHeaderAnalyzer::class)->setClient(new Client(
+            ['handler' => new MockHandler([
+                new Response(200, []),
+            ])]
+        ));
+
+        Route::get('/login', function () {
+            //
+        })->name('login');
+
+        $this->runEnlightn();
+
+        $this->assertFailed(HSTSHeaderAnalyzer::class);
+    }
+
+    /**
+     * @test
+     */
+    public function detects_missing_hsts_header_for_secure_cookie_attributes()
     {
         $this->registerStatefulGlobalMiddleware();
 
@@ -63,6 +87,7 @@ class HSTSHeaderAnalyzerTest extends AnalyzerTestCase
         $this->registerStatefulGlobalMiddleware();
 
         $this->app->config->set('session.secure', true);
+        $this->app->config->set('app.url', 'https://localhost');
 
         $this->app->make(HSTSHeaderAnalyzer::class)->setClient(new Client(
             ['handler' => new MockHandler([


### PR DESCRIPTION
Currently, we only check the session secure configuration. It would be helpful to also check the app URL.