### PR TITLE
Add function check for opcache_get_configuration so it gracefully fails

### DIFF
--- a/src/Analyzers/Performance/OpcacheAnalyzer.php
+++ b/src/Analyzers/Performance/OpcacheAnalyzer.php
@@ -43,7 +43,8 @@ class OpcacheAnalyzer extends PerformanceAnalyzer
      */
     public function handle()
     {
-        if (opcache_get_configuration()['directives']['opcache.enable'] ?? false) {
+        if (function_exists('opcache_get_configuration')
+            && opcache_get_configuration()['directives']['opcache.enable'] ?? false) {
             return;
         }
 


### PR DESCRIPTION
Hi,

Thanks for all the great work you have done on this package. Really impressed with what it achieves already. I have just tried to run this on bitbucket pipelines and ran into the following issue:-

 `Call to undefined function Enlightn\Enlightn\Analyzers\Performance\opcache_get_configuration()` 

due to opcache not being installed in the PHP image. Therefore I felt it would be appropriate to add a check to handle this gracefully.