### PR TITLE
Fix logo for white terminals

### DIFF
--- a/src/Console/EnlightnCommand.php
+++ b/src/Console/EnlightnCommand.php
@@ -265,7 +265,7 @@ class EnlightnCommand extends Command
             't' => 'green',
             'ns' => 'green',
         ])->each(function ($color, $tag) {
-            $this->output->getFormatter()->setStyle($tag, new OutputFormatterStyle($color, 'black'));
+            $this->output->getFormatter()->setStyle($tag, new OutputFormatterStyle($color));
         });
 
     }


### PR DESCRIPTION
Thanks to one of @PovilasKorop's reviews, discovered a bug where the Enlightn logo shows up with a wierd black background on white terminals. This PR fixes this.