### PR TITLE
Add ability to exclude analyzers from reporting for CI/CD

### DIFF
--- a/config/enlightn.php
+++ b/config/enlightn.php
@@ -75,6 +75,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Exclusions From Reporting
+    |--------------------------------------------------------------------------
+    |
+    | Specify the analyzer classes that you wish to exclude from reporting. This
+    | means that if any of these analyzers fail, they will not be counted
+    | towards the exit status of the Enlightn command. This is useful
+    | if you wish to run the command in your CI/CD pipeline.
+    | Example: [\Enlightn\Enlightn\Analyzers\Security\XSSAnalyzer::class].
+    |
+    */
+    'dont_report' => [],
+
+    /*
+    |--------------------------------------------------------------------------
     | Analyzer Configurations
     |--------------------------------------------------------------------------
     |

--- a/src/Analyzers/Analyzer.php
+++ b/src/Analyzers/Analyzer.php
@@ -225,6 +225,7 @@ abstract class Analyzer
             'error' => ($this->getStatus() == 'failed') ? $this->getErrorMessage() : null,
             'traces' => $this->traces,
             'docsUrl' => $this->getDocsUrl(),
+            'reportable' => ! in_array(static::class, config('enlightn.dont_report', [])),
         ];
     }
 

--- a/src/Console/EnlightnCommand.php
+++ b/src/Console/EnlightnCommand.php
@@ -89,7 +89,7 @@ class EnlightnCommand extends Command
 
         // Exit with a non-zero exit code if there were failed checks to throw an error on CI environments
         return collect($this->result)->sum(function ($category) {
-            return $category['failed'];
+            return $category['reported'];
         }) == 0 ? 0 : 1;
     }
 
@@ -156,6 +156,7 @@ class EnlightnCommand extends Command
                 'failed' => 0,
                 'skipped' => 0,
                 'error' => 0,
+                'reported' => 0,
             ];
         }
 
@@ -224,6 +225,10 @@ class EnlightnCommand extends Command
     {
         $this->result[$info['category']][$info['status']]++;
         $this->result['Total'][$info['status']]++;
+        if ($info['status'] === 'failed' && ($info['reportable'] ?? true)) {
+            $this->result[$info['category']]['reported']++;
+            $this->result['Total']['reported']++;
+        }
     }
 
     /**

--- a/tests/EnlightnCommandTest.php
+++ b/tests/EnlightnCommandTest.php
@@ -56,4 +56,30 @@ class EnlightnCommandTest extends TestCase
 
         $this->artisan('enlightn')->assertExitCode(1);
     }
+
+    /**
+     * @test
+     */
+    public function command_exits_with_success_status_code_if_not_reportable()
+    {
+        $this->app->config->set('enlightn.analyzers', AppDebugAnalyzer::class);
+        $this->app->config->set('app.env', 'production');
+        $this->app->config->set('app.debug', true);
+        $this->app->config->set('enlightn.dont_report', [AppDebugAnalyzer::class]);
+
+        $this->artisan('enlightn')->assertExitCode(0);
+    }
+
+    /**
+     * @test
+     */
+    public function command_exits_with_failure_status_code_if_any_one_reportable_fails()
+    {
+        $this->app->config->set('enlightn.analyzers', [AppDebugAnalyzer::class, CachePrefixAnalyzer::class]);
+        $this->app->config->set('app.env', 'production');
+        $this->app->config->set('app.debug', true);
+        $this->app->config->set('enlightn.dont_report', [AppDebugAnalyzer::class]);
+
+        $this->artisan('enlightn')->assertExitCode(1);
+    }
 }


### PR DESCRIPTION
This PR adds the ability to exclude analyzers from reporting (for counting towards the exit status code of the `enlightn` Artisan command). This was originally suggested by @Jubeki in #1.

/cc @m1guelpf