### PR TITLE
Add CC0 and Unlicense to list of whitelisted licenses

### DIFF
--- a/config/enlightn.php
+++ b/config/enlightn.php
@@ -100,6 +100,7 @@ return [
     'license_whitelist' => [
         'Apache-2.0', 'Apache2', 'BSD-2-Clause', 'BSD-3-Clause', 'LGPL-2.1-only', 'LGPL-2.1',
         'LGPL-2.1-or-later', 'LGPL-3.0', 'LGPL-3.0-only', 'LGPL-3.0-or-later', 'MIT', 'ISC',
+        'CC0-1.0', 'Unlicense',
     ],
 
     // List your commercial packages (licensed by you) below, so that they are not

--- a/src/Analyzers/Security/LicenseAnalyzer.php
+++ b/src/Analyzers/Security/LicenseAnalyzer.php
@@ -65,6 +65,7 @@ class LicenseAnalyzer extends SecurityAnalyzer
         $whitelistedLicenses = array_map('strtoupper', config('enlightn.license_whitelist', [
             'Apache-2.0', 'Apache2', 'BSD-2-Clause', 'BSD-3-Clause', 'LGPL-2.1-only', 'LGPL-2.1',
             'LGPL-2.1-or-later', 'LGPL-3.0', 'LGPL-3.0-only', 'LGPL-3.0-or-later', 'MIT', 'ISC',
+            'CC0-1.0', 'Unlicense',
         ]));
 
         $commercialPackages = config('enlightn.commercial_packages', []);


### PR DESCRIPTION
CC0 and Unlicense are also licenses that are safe to use. This PR adds them to the list of whitelisted licenses. Fixes https://github.com/enlightn/enlightn/discussions/14.