### PR TITLE
Add option to disable compact files in checks

### DIFF
--- a/config/enlightn.php
+++ b/config/enlightn.php
@@ -103,6 +103,10 @@ return [
         'CC0-1.0', 'Unlicense',
     ],
 
+    // Set to true to restrict the max lines of code/files displayed in the enlightn
+    // command for each check. Set to false to display all lines/files.
+    'compact_lines' => true,
+
     // List your commercial packages (licensed by you) below, so that they are not
     // flagged by the License Analyzer.
     'commercial_packages' => [

--- a/config/enlightn.php
+++ b/config/enlightn.php
@@ -103,8 +103,8 @@ return [
         'CC0-1.0', 'Unlicense',
     ],
 
-    // Set to true to restrict the max lines of code/files displayed in the enlightn
-    // command for each check. Set to false to display all lines/files.
+    // Set to true to restrict the max number of files displayed in the enlightn
+    // command for each check. Set to false to display all files.
     'compact_lines' => true,
 
     // List your commercial packages (licensed by you) below, so that they are not

--- a/src/Console/EnlightnCommand.php
+++ b/src/Console/EnlightnCommand.php
@@ -60,6 +60,13 @@ class EnlightnCommand extends Command
     protected $result = [];
 
     /**
+     * Indicates whether to limit the number of lines or files displayed in each check.
+     *
+     * @var bool
+     */
+    protected $compactLines;
+
+    /**
      * Execute the console command.
      *
      * @return int
@@ -79,6 +86,7 @@ class EnlightnCommand extends Command
         $this->totalAnalyzers = Enlightn::totalAnalyzers();
         $this->countAnalyzers = 1;
         $this->initializeResult();
+        $this->compactLines = config('enlightn.compact_lines', true);
 
         Enlightn::using([$this, 'printAnalyzerOutput']);
         Enlightn::run($this->laravel);
@@ -118,7 +126,7 @@ class EnlightnCommand extends Command
             $this->line("<fg=red>{$error}</fg=red>");
 
             if (! empty($info['traces'])) {
-                collect($info['traces'])->when(empty($this->analyzerClasses), function($collection) {
+                collect($info['traces'])->when(empty($this->analyzerClasses) && $this->compactLines, function($collection) {
                     return $collection->take(5);
                 })->each(function ($lineNumbers, $path) {
                     $this->line(
@@ -127,7 +135,7 @@ class EnlightnCommand extends Command
                     );
                 });
 
-                if (count($info['traces']) > 5 && empty($this->analyzerClasses)) {
+                if (count($info['traces']) > 5 && empty($this->analyzerClasses) && $this->compactLines) {
                     $this->line("<fg=magenta>And "
                         .(count($info['traces']) - 5)
                         ."</fg=magenta> more file(s).");


### PR DESCRIPTION
Currently, the `enlightn` command restricts the max number of files to 5. Beyond that it shows a message like "and 5 more file(s)". This PR allows the option to disable this restriction and display all files by setting the `compact_lines` configuration option to false.

Fixes #13.