### PR TITLE
Support custom categories

### DIFF
--- a/src/Console/EnlightnCommand.php
+++ b/src/Console/EnlightnCommand.php
@@ -150,7 +150,7 @@ class EnlightnCommand extends Command
     {
         $this->result = [];
 
-        foreach (['Performance', 'Security', 'Reliability', 'Total'] as $category) {
+        foreach (array_merge(Enlightn::$categories, ['Total']) as $category) {
             $this->result[$category] = [
                 'passed' => 0,
                 'failed' => 0,
@@ -176,15 +176,13 @@ class EnlightnCommand extends Command
         $rightAlign = (new TableStyle())->setPadType(STR_PAD_LEFT);
 
         $this->table(
-            ['Status', 'Performance', 'Security', 'Reliability', 'Total'],
+            array_merge(['Status'], Enlightn::$categories, ['Total']),
             collect(['passed', 'failed', 'skipped', 'error'])->map(function ($status) {
-                return [
-                    $status == 'skipped' ? 'Not Applicable' : ucfirst($status),
-                    $this->formatResult($status, 'Performance'),
-                    $this->formatResult($status, 'Security'),
-                    $this->formatResult($status, 'Reliability'),
-                    $this->formatResult($status, 'Total'),
-                ];
+                return array_merge([$status === 'skipped' ? 'Not Applicable' : ucfirst($status)],
+                    collect(array_merge(Enlightn::$categories, ['Total']))->map(function ($category) use ($status) {
+                        return $this->formatResult($status, $category);
+                    })->toArray()
+                );
             })->values()->toArray(),
             'default',
             ['default', $rightAlign, $rightAlign, $rightAlign, $rightAlign]

--- a/src/Enlightn.php
+++ b/src/Enlightn.php
@@ -284,12 +284,25 @@ class Enlightn
         if (is_subclass_of($class, Analyzer::class) &&
                 ! (new ReflectionClass($class))->isAbstract() &&
                 ! static::hasAnalyzer($class)) {
-            $category = get_class_vars($class)['category'];
-            if (!is_null($category) && !self::hasCategory($category)) {
-                static::$categories[] = $category;
-            }
-
             static::$analyzerClasses[] = $class;
+
+            static::registerCategory($class);
+        }
+    }
+
+    /**
+     * Register an Enlightn analyzer category.
+     *
+     * @param string $class
+     * @return void
+     */
+    protected static function registerCategory($class)
+    {
+        $category = get_class_vars($class)['category'];
+
+        if (! is_null($category) && ! self::hasCategory($category)) {
+            static::$categories[] = $category;
+            static::$categories = Arr::sort(static::$categories);
         }
     }
 }

--- a/src/Enlightn.php
+++ b/src/Enlightn.php
@@ -26,6 +26,13 @@ class Enlightn
     public static $analyzers = [];
 
     /**
+     * The registered analyzer categories
+     *
+     * @var array
+     */
+    public static $categories = [];
+
+    /**
      * The callback to be executed after an analyzer is run.
      *
      * @var callable|null
@@ -127,6 +134,8 @@ class Enlightn
     {
         static::$analyzers = [];
 
+        static::$categories = [];
+
         static::$analyzerClasses = [];
 
         static::$afterCallback = null;
@@ -141,6 +150,17 @@ class Enlightn
     public static function hasAnalyzer(string $class)
     {
         return in_array($class, static::$analyzerClasses);
+    }
+
+    /**
+     * Determine if a given category has been registered.
+     *
+     * @param string $category
+     * @return bool
+     */
+    public static function hasCategory(string $category)
+    {
+        return in_array($category, static::$categories);
     }
 
     /**
@@ -264,6 +284,11 @@ class Enlightn
         if (is_subclass_of($class, Analyzer::class) &&
                 ! (new ReflectionClass($class))->isAbstract() &&
                 ! static::hasAnalyzer($class)) {
+            $category = get_class_vars($class)['category'];
+            if (!is_null($category) && !self::hasCategory($category)) {
+                static::$categories[] = $category;
+            }
+
             static::$analyzerClasses[] = $class;
         }
     }

--- a/tests/EnlightnTest.php
+++ b/tests/EnlightnTest.php
@@ -2,9 +2,14 @@
 
 namespace Enlightn\Enlightn\Tests;
 
+use Enlightn\Enlightn\Analyzers\Performance\SessionDriverAnalyzer;
+use Enlightn\Enlightn\Analyzers\Reliability\DeadCodeAnalyzer;
+use Enlightn\Enlightn\Analyzers\Security\CSRFAnalyzer;
 use Enlightn\Enlightn\Enlightn;
 use Enlightn\Enlightn\Analyzers\Analyzer;
 use Enlightn\Enlightn\Analyzers\Security\AppDebugAnalyzer;
+use Enlightn\Enlightn\Tests\Stubs\CustomAnalyzer;
+use Enlightn\Enlightn\Tests\Stubs\CustomCategoryStub;
 use Mockery as m;
 
 class EnlightnTest extends TestCase
@@ -25,6 +30,26 @@ class EnlightnTest extends TestCase
 
         $this->assertContains(AppDebugAnalyzer::class, Enlightn::$analyzerClasses);
         $this->assertNotContains(Analyzer::class, Enlightn::$analyzerClasses);
+    }
+
+    /**
+     * @test
+     */
+    public function registers_analyzer_categories()
+    {
+        $this->app->config->set(
+            'enlightn.analyzers',
+            [
+                CSRFAnalyzer::class,
+                SessionDriverAnalyzer::class,
+                DeadCodeAnalyzer::class,
+                CustomCategoryStub::class,
+            ]
+        );
+
+        Enlightn::register();
+
+        $this->assertEquals(['Security', 'Performance', 'Reliability', 'Custom'], Enlightn::$categories);
     }
 
     /**

--- a/tests/EnlightnTest.php
+++ b/tests/EnlightnTest.php
@@ -8,7 +8,6 @@ use Enlightn\Enlightn\Analyzers\Security\CSRFAnalyzer;
 use Enlightn\Enlightn\Enlightn;
 use Enlightn\Enlightn\Analyzers\Analyzer;
 use Enlightn\Enlightn\Analyzers\Security\AppDebugAnalyzer;
-use Enlightn\Enlightn\Tests\Stubs\CustomAnalyzer;
 use Enlightn\Enlightn\Tests\Stubs\CustomCategoryStub;
 use Mockery as m;
 

--- a/tests/Stubs/CustomCategoryStub.php
+++ b/tests/Stubs/CustomCategoryStub.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Enlightn\Enlightn\Tests\Stubs;
+
+use Enlightn\Enlightn\Analyzers\Analyzer;
+
+class CustomCategoryStub extends Analyzer
+{
+    /**
+     * The category of the analyzer.
+     *
+     * @var string|null
+     */
+    public $category = 'Custom';
+}


### PR DESCRIPTION
Hi again,

When consuming your package I wanted a way of adding a new category for a custom analyzer. E.g. 'Consistency' where analyzers could be added to check a project follows certain consistent styles in code. E.g. the use of invokable controllers.

Upon doing so I added a new abstract analyzer within the analyzers class path like so:-

```
<?php

namespace Enlightn\Enlightn\Analyzers\Consistency;

use Enlightn\Enlightn\Analyzers\Analyzer;

abstract class ConsistencyAnalyzer extends Analyzer
{
    /**
     * The category of the analyzer.
     *
     * @var string|null
     */
    public $category = 'Consistency';
}
```

I then got the custom analyzer to extend upon this.

```
class InvokableControllerAnalyzer extends ConsistencyAnalyzer
{
}
```

however unfortunately the Enlightn command ran into an error due to the categories array being hard coded within the classes. 

`  Undefined array key "Consistency"` within the `updateResult` method.

Therefore the change submitted dynamically picks up categories via the analyzer paths and adds them to the categories array which can then build out the output via the command. I have created a basic stub to show this.

Looking for further guidance on this, e.g. I am currently aware the same order of categories is not in place, but that could be sorted alphabetically etc.

Feel free to reject/take this on further if you need to and once again thanks for all the great work you are doing! 🙂 

