### PR TITLE
Add analyzer to detect syntax errors

### DIFF
--- a/src/Analyzers/Reliability/SyntaxErrorAnalyzer.php
+++ b/src/Analyzers/Reliability/SyntaxErrorAnalyzer.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Enlightn\Enlightn\Analyzers\Reliability;
+
+use Enlightn\Enlightn\Inspection\Inspector;
+
+class SyntaxErrorAnalyzer extends ReliabilityAnalyzer
+{
+    /**
+     * The title describing the analyzer.
+     *
+     * @var string|null
+     */
+    public $title = 'There are no syntax errors in your application code.';
+
+    /**
+     * The severity of the analyzer.
+     *
+     * @var string|null
+     */
+    public $severity = self::SEVERITY_CRITICAL;
+
+    /**
+     * The time to fix in minutes.
+     *
+     * @var int|null
+     */
+    public $timeToFix = 5;
+
+    /**
+     * Get the error message describing the analyzer insights.
+     *
+     * @return string
+     */
+    public function errorMessage()
+    {
+        return "Your application has some PHP files with syntax errors.";
+    }
+
+    /**
+     * Execute the analyzer.
+     *
+     * @param \Enlightn\Enlightn\Inspection\Inspector $inspector
+     * @return void
+     */
+    public function handle(Inspector $inspector)
+    {
+        if (count($inspector->errors) > 0) {
+            $this->markFailed();
+
+            foreach ($inspector->errors as $path => $lineNumbers) {
+                $this->addTraces($path, $lineNumbers);
+            }
+        }
+    }
+}

--- a/tests/Analyzers/Reliability/SyntaxErrorAnalyzerTest.php
+++ b/tests/Analyzers/Reliability/SyntaxErrorAnalyzerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Enlightn\Enlightn\Tests\Analyzers\Reliability;
+
+use Enlightn\Enlightn\Tests\Analyzers\AnalyzerTestCase;
+use Enlightn\Enlightn\Analyzers\Reliability\SyntaxErrorAnalyzer;
+use Enlightn\Enlightn\Tests\Stubs\DummyStub;
+
+class SyntaxErrorAnalyzerTest extends AnalyzerTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $this->setupEnvironmentFor(SyntaxErrorAnalyzer::class, $app);
+    }
+
+    /**
+     * @test
+     */
+    public function detects_syntax_errors()
+    {
+        $this->app->config->set('enlightn.base_path', $this->getBaseStubPath());
+
+        $this->runEnlightn();
+
+        $errorPath = $this->getBaseStubPath().DIRECTORY_SEPARATOR.'SyntaxErrorStub.php';
+
+        $this->assertFailedAt(SyntaxErrorAnalyzer::class, $errorPath, 5);
+        $this->assertFailedAt(SyntaxErrorAnalyzer::class, $errorPath, 7);
+        $this->assertHasErrors(SyntaxErrorAnalyzer::class, 2);
+    }
+
+    /**
+     * @test
+     */
+    public function passes_with_no_errors()
+    {
+        $this->setBasePathFrom(DummyStub::class);
+
+        $this->runEnlightn();
+
+        $this->assertPassed(SyntaxErrorAnalyzer::class);
+    }
+}

--- a/tests/Stubs/SyntaxErrorStub.php
+++ b/tests/Stubs/SyntaxErrorStub.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Enlightn\Enlightn\Tests\Stubs;
+
+class SyntaxErrorStub;
+{
+    public function test();
+}


### PR DESCRIPTION
Some Enlightn users were experiencing crashes when their files had syntax errors. https://github.com/enlightn/enlightn/pull/17 fixed that. 

This PR adds an additional analyzer to detect syntax errors and flag them as well.