### PR TITLE
Make improvements to static analysis

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,6 +16,8 @@ parameters:
     checkThisOnly: false
     checkUnionTypes: true
     checkExplicitMixed: true
+    stubFiles:
+        - stubs/Request.stub
 
 rules:
 	- Enlightn\Enlightn\PHPStan\FillableForeignKeyModelRule
@@ -102,3 +104,11 @@ services:
             functionReflector: @betterReflectionFunctionReflector
         tags:
             - phpstan.rules.rule
+    -
+        class: Enlightn\Enlightn\PHPStan\RequestDataTypeNodeResolverExtension
+        tags:
+            - phpstan.phpDoc.typeNodeResolverExtension
+    -
+        class: Enlightn\Enlightn\PHPStan\RequestArrayDataTypeNodeResolverExtension
+        tags:
+            - phpstan.phpDoc.typeNodeResolverExtension

--- a/src/PHPStan/AnalyzesNodes.php
+++ b/src/PHPStan/AnalyzesNodes.php
@@ -11,10 +11,41 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
 
 trait AnalyzesNodes
 {
+    /**
+     * Determine whether the Expr was called on a Request instance.
+     *
+     * @param \PhpParser\Node\Expr $expr
+     * @param \PHPStan\Analyser\Scope $scope
+     * @return bool
+     */
+    protected function isRequestArrayData(Expr $expr, Scope $scope)
+    {
+        $logic = (new RequestArrayDataType(new StringType, new StringType))
+            ->isSuperTypeOf($scope->getType($expr));
+
+        return $logic->yes() || $logic->maybe();
+    }
+
+    /**
+     * Determine whether the Expr was called on a Request instance.
+     *
+     * @param \PhpParser\Node\Expr $expr
+     * @param \PHPStan\Analyser\Scope $scope
+     * @return bool
+     */
+    protected function isRequestData(Expr $expr, Scope $scope)
+    {
+        $logic = (new RequestDataType)->isSuperTypeOf($scope->getType($expr));
+
+        return $logic->yes() || $logic->maybe();
+    }
+
     /**
      * Determine whether the Expr was called on a Request instance.
      *
@@ -57,10 +88,12 @@ trait AnalyzesNodes
      */
     protected function hasRequestCall(Node $node, Scope $scope)
     {
-        return $node instanceof MethodCall
-            && $this->isCalledOnRequest($node->var, $scope)
-            && $node->name instanceof Node\Identifier
-            && in_array($node->name->toString(), ['input', 'get', 'post', 'query', 'all']);
+        if ($node instanceof Expr) {
+            return $this->isRequestData($node, $scope)
+                || $this->isRequestArrayData($node, $scope);
+        }
+
+        return false;
     }
 
     /**
@@ -147,5 +180,15 @@ trait AnalyzesNodes
         }
 
         return false;
+    }
+
+    protected function blacklistedRequestDataMethods()
+    {
+        return ['input', 'get', 'post', 'query', 'old', 'cookie', 'header'];
+    }
+
+    protected function allBlacklistedRequestMethods()
+    {
+        return array_merge($this->blacklistedRequestDataMethods(), ['all', 'except']);
     }
 }

--- a/src/PHPStan/AnalyzesNodes.php
+++ b/src/PHPStan/AnalyzesNodes.php
@@ -11,9 +11,10 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
-use PHPStan\Type\MixedType;
+use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
+use PHPStan\Type\UnionType;
 
 trait AnalyzesNodes
 {
@@ -26,8 +27,8 @@ trait AnalyzesNodes
      */
     protected function isRequestArrayData(Expr $expr, Scope $scope)
     {
-        $logic = (new RequestArrayDataType(new StringType, new StringType))
-            ->isSuperTypeOf($scope->getType($expr));
+        $logic = (new RequestArrayDataType(new UnionType([new StringType, new IntegerType]), new RequestDataType))
+            ->canBeSuperTypeOf($scope->getType($expr));
 
         return $logic->yes() || $logic->maybe();
     }
@@ -41,7 +42,7 @@ trait AnalyzesNodes
      */
     protected function isRequestData(Expr $expr, Scope $scope)
     {
-        $logic = (new RequestDataType)->isSuperTypeOf($scope->getType($expr));
+        $logic = (new RequestDataType)->canBeSuperTypeOf($scope->getType($expr));
 
         return $logic->yes() || $logic->maybe();
     }

--- a/src/PHPStan/MassAssignmentBuilderInstanceRule.php
+++ b/src/PHPStan/MassAssignmentBuilderInstanceRule.php
@@ -57,9 +57,6 @@ class MassAssignmentBuilderInstanceRule implements Rule
      */
     protected function retrievesRequestInput(Node\Arg $arg, Scope $scope)
     {
-        return $arg->value instanceof MethodCall
-            && $this->isCalledOnRequest($arg->value->var, $scope)
-            && $arg->value->name instanceof Node\Identifier
-            && $arg->value->name->toString() === 'all';
+        return $arg->value instanceof Node\Expr && $this->isRequestArrayData($arg->value, $scope);
     }
 }

--- a/src/PHPStan/MassAssignmentModelInstanceRule.php
+++ b/src/PHPStan/MassAssignmentModelInstanceRule.php
@@ -56,9 +56,6 @@ class MassAssignmentModelInstanceRule implements Rule
      */
     protected function retrievesRequestInput(Node\Arg $arg, Scope $scope)
     {
-        return $arg->value instanceof MethodCall
-            && $this->isCalledOnRequest($arg->value->var, $scope)
-            && $arg->value->name instanceof Node\Identifier
-            && $arg->value->name->toString() === 'all';
+        return $arg->value instanceof Node\Expr && $this->isRequestArrayData($arg->value, $scope);
     }
 }

--- a/src/PHPStan/MassAssignmentModelStaticRule.php
+++ b/src/PHPStan/MassAssignmentModelStaticRule.php
@@ -68,9 +68,6 @@ class MassAssignmentModelStaticRule implements Rule
      */
     protected function retrievesRequestInput(Node\Arg $arg, Scope $scope)
     {
-        return $arg->value instanceof MethodCall
-            && $this->isCalledOnRequest($arg->value->var, $scope)
-            && $arg->value->name instanceof Node\Identifier
-            && $arg->value->name->toString() === 'all';
+        return $arg->value instanceof Node\Expr && $this->isRequestArrayData($arg->value, $scope);
     }
 }

--- a/src/PHPStan/RequestArrayDataType.php
+++ b/src/PHPStan/RequestArrayDataType.php
@@ -8,6 +8,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
 
 class RequestArrayDataType extends ArrayType
 {
@@ -17,6 +18,17 @@ class RequestArrayDataType extends ArrayType
             return TrinaryLogic::createYes();
         }
         if ($type instanceof CompoundType) {
+            return $type->isSubTypeOf($this);
+        }
+        return TrinaryLogic::createNo();
+    }
+
+    public function canBeSuperTypeOf(Type $type): TrinaryLogic
+    {
+        if ($type instanceof self) {
+            return TrinaryLogic::createYes();
+        }
+        if ($type instanceof UnionType) {
             return $type->isSubTypeOf($this);
         }
         return TrinaryLogic::createNo();

--- a/src/PHPStan/RequestArrayDataType.php
+++ b/src/PHPStan/RequestArrayDataType.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enlightn\Enlightn\PHPStan;
+
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\CompoundType;
+use PHPStan\Type\Type;
+
+class RequestArrayDataType extends ArrayType
+{
+    public function isSuperTypeOf(Type $type): TrinaryLogic
+    {
+        if ($type instanceof self) {
+            return TrinaryLogic::createYes();
+        }
+        if ($type instanceof CompoundType) {
+            return $type->isSubTypeOf($this);
+        }
+        return TrinaryLogic::createNo();
+    }
+
+    /**
+     * @param mixed[] $properties
+     * @return Type
+     */
+    public static function __set_state(array $properties): Type
+    {
+        return new self($properties['keyType'], $properties['itemType']);
+    }
+}

--- a/src/PHPStan/RequestArrayDataTypeNodeResolverExtension.php
+++ b/src/PHPStan/RequestArrayDataTypeNodeResolverExtension.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enlightn\Enlightn\PHPStan;
+
+use PHPStan\Analyser\NameScope;
+use PHPStan\PhpDoc\TypeNodeResolverExtension;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+
+class RequestArrayDataTypeNodeResolverExtension implements TypeNodeResolverExtension
+{
+    public function resolve(TypeNode $typeNode, NameScope $nameScope): ?Type
+    {
+        if ($typeNode instanceof IdentifierTypeNode && $typeNode->name === 'request-array') {
+            return new RequestArrayDataType(new UnionType([new StringType, new IntegerType]), new StringType);
+        }
+
+        return null;
+    }
+}

--- a/src/PHPStan/RequestArrayDataTypeNodeResolverExtension.php
+++ b/src/PHPStan/RequestArrayDataTypeNodeResolverExtension.php
@@ -18,7 +18,7 @@ class RequestArrayDataTypeNodeResolverExtension implements TypeNodeResolverExten
     public function resolve(TypeNode $typeNode, NameScope $nameScope): ?Type
     {
         if ($typeNode instanceof IdentifierTypeNode && $typeNode->name === 'request-array') {
-            return new RequestArrayDataType(new UnionType([new StringType, new IntegerType]), new StringType);
+            return new RequestArrayDataType(new UnionType([new StringType, new IntegerType]), new RequestDataType);
         }
 
         return null;

--- a/src/PHPStan/RequestDataType.php
+++ b/src/PHPStan/RequestDataType.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enlightn\Enlightn\PHPStan;
+
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+
+class RequestDataType extends StringType
+{
+    /**
+     * @param mixed[] $properties
+     * @return Type
+     */
+    public static function __set_state(array $properties): Type
+    {
+        return new self();
+    }
+}

--- a/src/PHPStan/RequestDataType.php
+++ b/src/PHPStan/RequestDataType.php
@@ -8,6 +8,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
 
 class RequestDataType extends StringType
 {
@@ -26,6 +27,17 @@ class RequestDataType extends StringType
             return TrinaryLogic::createYes();
         }
         if ($type instanceof CompoundType) {
+            return $type->isSubTypeOf($this);
+        }
+        return TrinaryLogic::createNo();
+    }
+
+    public function canBeSuperTypeOf(Type $type): TrinaryLogic
+    {
+        if ($type instanceof self) {
+            return TrinaryLogic::createYes();
+        }
+        if ($type instanceof UnionType) {
             return $type->isSubTypeOf($this);
         }
         return TrinaryLogic::createNo();

--- a/src/PHPStan/RequestDataType.php
+++ b/src/PHPStan/RequestDataType.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Enlightn\Enlightn\PHPStan;
 
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\CompoundType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 
@@ -16,5 +18,16 @@ class RequestDataType extends StringType
     public static function __set_state(array $properties): Type
     {
         return new self();
+    }
+
+    public function isSuperTypeOf(Type $type) : TrinaryLogic
+    {
+        if ($type instanceof self) {
+            return TrinaryLogic::createYes();
+        }
+        if ($type instanceof CompoundType) {
+            return $type->isSubTypeOf($this);
+        }
+        return TrinaryLogic::createNo();
     }
 }

--- a/src/PHPStan/RequestDataTypeNodeResolverExtension.php
+++ b/src/PHPStan/RequestDataTypeNodeResolverExtension.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enlightn\Enlightn\PHPStan;
+
+use PHPStan\Analyser\NameScope;
+use PHPStan\PhpDoc\TypeNodeResolverExtension;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\Type;
+
+class RequestDataTypeNodeResolverExtension implements TypeNodeResolverExtension
+{
+    public function resolve(TypeNode $typeNode, NameScope $nameScope): ?Type
+    {
+        if ($typeNode instanceof IdentifierTypeNode && $typeNode->name === 'request-data') {
+            return new RequestDataType();
+        }
+
+        return null;
+    }
+}

--- a/stubs/Request.stub
+++ b/stubs/Request.stub
@@ -1,0 +1,105 @@
+<?php
+
+namespace Illuminate\Http;
+
+class Request
+{
+    /**
+     * This method belongs to Symfony HttpFoundation and is not usually needed when using Laravel.
+     *
+     * Instead, you may use the "input" method.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @phpstan-return request-data|request-array|string|null
+     */
+    public function get(string $key, $default = null)
+    {
+    }
+
+    /**
+     * Retrieve an input item from the request.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @phpstan-return request-data|request-array|string|null
+     */
+    public function input($key = null, $default = null)
+    {
+    }
+
+    /**
+     * Retrieve a query string item from the request.
+     *
+     * @param  string|null  $key
+     * @param  string|array<int|string,mixed>|null  $default
+     * @phpstan-return request-data|request-array|string|null
+     */
+    public function query($key = null, $default = null)
+    {
+    }
+
+    /**
+     * Retrieve a request payload item from the request.
+     *
+     * @param  string|null  $key
+     * @param  string|array<int|string,mixed>|null  $default
+     * @phpstan-return request-data|request-array|string|null
+     */
+    public function post($key = null, $default = null)
+    {
+    }
+
+    /**
+     * Retrieve an old input item.
+     *
+     * @param  string|null  $key
+     * @param  string|array<int|string,mixed>|null  $default
+     * @phpstan-return request-data|request-array|string
+     */
+    public function old($key = null, $default = null)
+    {
+    }
+
+    /**
+     * Retrieve a cookie from the request.
+     *
+     * @param  string|null  $key
+     * @param  string|array<int,string>|null  $default
+     * @phpstan-return request-data|request-array|string|null
+     */
+    public function cookie($key = null, $default = null)
+    {
+    }
+
+    /**
+     * Retrieve a header from the request.
+     *
+     * @param  string|null  $key
+     * @param  string|array<int,string>|null  $default
+     * @phpstan-return request-data|request-array|string|null
+     */
+    public function header($key = null, $default = null)
+    {
+    }
+
+    /**
+     * Get all of the input and files for the request.
+     *
+     * @param  array<int,string>|mixed|null  $keys
+     * @phpstan-return request-array
+     */
+    public function all($keys = null)
+    {
+    }
+
+    /**
+     * Get all of the input except for a specified array of items.
+     *
+     * @param  array<int,string>|mixed  $keys
+     * @phpstan-return request-array
+     */
+    public function except($keys)
+    {
+    }
+}

--- a/stubs/Request.stub
+++ b/stubs/Request.stub
@@ -11,7 +11,7 @@ class Request
      *
      * @param  string  $key
      * @param  mixed  $default
-     * @phpstan-return request-data|request-array|null
+     * @phpstan-return request-data|array<int,request-data>|null
      */
     public function get(string $key, $default = null)
     {
@@ -22,7 +22,7 @@ class Request
      *
      * @param  string|null  $key
      * @param  mixed  $default
-     * @phpstan-return request-data|request-array|null
+     * @phpstan-return request-data|array<int,request-data>|null
      */
     public function input($key = null, $default = null)
     {
@@ -33,7 +33,7 @@ class Request
      *
      * @param  string|null  $key
      * @param  string|array<int|string,mixed>|null  $default
-     * @phpstan-return request-data|request-array|null
+     * @phpstan-return request-data|array<int,request-data>|null
      */
     public function query($key = null, $default = null)
     {
@@ -44,7 +44,7 @@ class Request
      *
      * @param  string|null  $key
      * @param  string|array<int|string,mixed>|null  $default
-     * @phpstan-return request-data|request-array|null
+     * @phpstan-return request-data|array<int,request-data>|null
      */
     public function post($key = null, $default = null)
     {
@@ -55,7 +55,7 @@ class Request
      *
      * @param  string|null  $key
      * @param  string|array<int|string,mixed>|null  $default
-     * @phpstan-return request-data|request-array
+     * @phpstan-return request-data|array<int,request-data>
      */
     public function old($key = null, $default = null)
     {
@@ -66,7 +66,7 @@ class Request
      *
      * @param  string|null  $key
      * @param  string|array<int,string>|null  $default
-     * @phpstan-return request-data|request-array|null
+     * @phpstan-return request-data|array<int,request-data>|null
      */
     public function cookie($key = null, $default = null)
     {
@@ -77,7 +77,7 @@ class Request
      *
      * @param  string|null  $key
      * @param  string|array<int,string>|null  $default
-     * @phpstan-return request-data|request-array|null
+     * @phpstan-return request-data|array<int,request-data>|null
      */
     public function header($key = null, $default = null)
     {
@@ -100,6 +100,16 @@ class Request
      * @phpstan-return request-array
      */
     public function except($keys)
+    {
+    }
+
+    /**
+     * Get a subset containing the provided keys with values from the input data.
+     *
+     * @param  array|mixed  $keys
+     * @phpstan-return array<string,request-data>
+     */
+    public function only($keys)
     {
     }
 }

--- a/stubs/Request.stub
+++ b/stubs/Request.stub
@@ -11,7 +11,7 @@ class Request
      *
      * @param  string  $key
      * @param  mixed  $default
-     * @phpstan-return request-data|request-array|string|null
+     * @phpstan-return request-data|request-array|null
      */
     public function get(string $key, $default = null)
     {
@@ -22,7 +22,7 @@ class Request
      *
      * @param  string|null  $key
      * @param  mixed  $default
-     * @phpstan-return request-data|request-array|string|null
+     * @phpstan-return request-data|request-array|null
      */
     public function input($key = null, $default = null)
     {
@@ -33,7 +33,7 @@ class Request
      *
      * @param  string|null  $key
      * @param  string|array<int|string,mixed>|null  $default
-     * @phpstan-return request-data|request-array|string|null
+     * @phpstan-return request-data|request-array|null
      */
     public function query($key = null, $default = null)
     {
@@ -44,7 +44,7 @@ class Request
      *
      * @param  string|null  $key
      * @param  string|array<int|string,mixed>|null  $default
-     * @phpstan-return request-data|request-array|string|null
+     * @phpstan-return request-data|request-array|null
      */
     public function post($key = null, $default = null)
     {
@@ -55,7 +55,7 @@ class Request
      *
      * @param  string|null  $key
      * @param  string|array<int|string,mixed>|null  $default
-     * @phpstan-return request-data|request-array|string
+     * @phpstan-return request-data|request-array
      */
     public function old($key = null, $default = null)
     {
@@ -66,7 +66,7 @@ class Request
      *
      * @param  string|null  $key
      * @param  string|array<int,string>|null  $default
-     * @phpstan-return request-data|request-array|string|null
+     * @phpstan-return request-data|request-array|null
      */
     public function cookie($key = null, $default = null)
     {
@@ -77,7 +77,7 @@ class Request
      *
      * @param  string|null  $key
      * @param  string|array<int,string>|null  $default
-     * @phpstan-return request-data|request-array|string|null
+     * @phpstan-return request-data|request-array|null
      */
     public function header($key = null, $default = null)
     {

--- a/tests/Analyzers/Security/MassAssignmentAnalyzerTest.php
+++ b/tests/Analyzers/Security/MassAssignmentAnalyzerTest.php
@@ -25,23 +25,27 @@ class MassAssignmentAnalyzerTest extends AnalyzerTestCase
 
         $this->runEnlightn();
 
-        $this->assertFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 25);
-        $this->assertFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 32);
-        $this->assertFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 37);
-        $this->assertFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 42);
+        $this->assertFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 26);
+        $this->assertFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 33);
+        $this->assertFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 38);
+        $this->assertFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 43);
 
-        $this->assertNotFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 13);
-        $this->assertNotFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 20);
+        $this->assertNotFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 14);
+        $this->assertNotFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 21);
 
-        $this->assertFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 47);
         $this->assertFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 48);
         $this->assertFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 49);
+        $this->assertFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 50);
+        $this->assertFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 56);
+        $this->assertFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 57);
 
-        $this->assertNotFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 54);
-        $this->assertNotFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 55);
-        $this->assertNotFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 56);
+        $this->assertNotFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 62);
+        $this->assertNotFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 63);
+        $this->assertNotFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 64);
+        $this->assertNotFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 70);
+        $this->assertNotFailedAt(MassAssignmentAnalyzer::class, $this->getClassStubPath(MassAssignmentStub::class), 71);
 
-        $this->assertHasErrors(MassAssignmentAnalyzer::class, 7);
+        $this->assertHasErrors(MassAssignmentAnalyzer::class, 9);
     }
 
     /**

--- a/tests/Stubs/MassAssignmentStub.php
+++ b/tests/Stubs/MassAssignmentStub.php
@@ -5,6 +5,7 @@ namespace Enlightn\Enlightn\Tests\Stubs;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 
 class MassAssignmentStub
 {
@@ -34,7 +35,7 @@ class MassAssignmentStub
 
     public function builderMassUpdateTest(Request $request)
     {
-        Product::update($request->all());
+        Product::query()->update($request->all());
     }
 
     public function firstOrCreateTest(Request $request)
@@ -49,11 +50,27 @@ class MassAssignmentStub
         Product::query()->upsert($request->all(), []);
     }
 
-    public function safeBuilderTest(Request $request)
+    public function savedRequestDataTest(FormRequest $request)
+    {
+        $x = $request->all();
+        Product::where('somestuff', 1)->update($x);
+        (new Product)->forceFill($x)->save();
+    }
+
+    public function safeBuilderTest(FormRequest $request)
     {
         Product::where('someColumn', 1)->update($request->validated());
         Product::where('someColumn', 1)->where('anothercolumn', 2)->update($request->only(['somevalues']));
         Product::query()->upsert($request->only(['ok']), []);
+    }
+
+    public function safeRequestDataWhitelistTest(Request $request)
+    {
+        $x = $request->all();
+        Product::where('somestuff', 1)->update(Arr::only($x, ['name', 'description']));
+        Product::where('somestuff', 1)->update(array_filter($x, function($key) {
+            return in_array($key, ['name', 'description']);
+        }));
     }
 }
 


### PR DESCRIPTION
This PR improves static analysis for identifying request input data (array or string form). This has been made possible with a Request stub and custom types/resolvers for request data.

Examples of what was not earlier flagged but is now flagged:

1. Storing data into variables was earlier skipped from analysis:
```php
use App\Models\Product;

$x = $request->all();
(new Product)->forceFill($x)->save();
```

2. `$request->except` was not flagged but now is. It's always better to whitelist than blacklist.

3. For request data (non-array), the `old`, `cookie` and `header` methods on the request object are also flagged as untrusted input data now since they can be modified at the client side.