### PR TITLE
Add details to analyzer fail messages

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,8 @@ name: tests
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -88,6 +88,26 @@ If you want to get the full Enlightn experience, it is recommended that you at l
 
 In case you don't want to run on production, you can simulate a production environment by setting your APP_ENV to production, setting up services and config as close to production as possible and running your production deployment script locally. Then run the Enlightn Artisan command.
 
+## View Detailed Error Messages
+
+By default, the `enlightn` Artisan command highlights the file paths, associated line numbers and a message for each failed check. If you wish to display detailed error messages for each line, you may use the `--details` option:
+
+```bash
+php artisan enlightn --details
+```
+
+## Usage in CI Environments
+
+If you wish to integrate Enlightn with your CI, you can simply trigger the `--ci` option when running Enlightn in your CI/CD tool:
+
+```bash
+php artisan enlightn --ci
+```
+
+Enlightn pre-configures which analyzers can be run in CI mode for you. So, the above command excludes analyzers that need a full setup to run (e.g. analyzers using dynamic analysis).
+
+For more information on CI integration, refer the [Enlightn documentation](https://www.laravel-enlightn.com/docs/getting-started/usage.html#usage-in-ci-environments).
+
 ## Failed Checks
 
 All checks that fail will include a description of why they failed along with the associated lines of code (if applicable) and a link to the documentation for the specific check.
@@ -106,7 +126,9 @@ The checks reported under the "Error" row indicate the analyzers that failed wit
 
 ## How Frequently Should I Run Enlightn?
 
-A good practice would be to run Enlightn every time you are deploying code or pushing or a new release. If your application is stable (not many new releases), then you might want to run Enlightn say once a month or so. Remember that Enlightn not only scans your application code but also monitors your application's health.
+A good practice would be to run Enlightn every time you are deploying code or pushing a new release. It is recommended to integrate Enlightn with your CI/CD tool so that it is triggered for every push or new release.
+
+Besides the automated CI checks, you might also want to run Enlightn on a regular frequency such as every week. This will allow you to monitor the dynamic analysis checks, which are typically excluded from CI tests.
 
 ## OS Compatibility
 

--- a/src/Analyzers/Analyzer.php
+++ b/src/Analyzers/Analyzer.php
@@ -124,20 +124,32 @@ abstract class Analyzer
      *
      * @param  string  $path
      * @param  int  $lineNumber
+     * @param  string|null  $details
      * @return $this
      */
-    public function addTrace(string $path, $lineNumber = 0)
+    public function addTrace(string $path, $lineNumber = 0, $details = null)
     {
         if ($lineNumber == 0) {
             return $this->markFailed();
         }
 
-        if (! isset($this->traces[$path])) {
-            $this->traces[$path] = [];
+        if (! in_array($trace = new Trace($path, $lineNumber, $details), $this->traces)) {
+            $this->traces[] = $trace;
         }
 
-        if (! in_array($lineNumber, $this->traces[$path])) {
-            $this->traces[$path][] = $lineNumber;
+        return $this->markFailed();
+    }
+
+    /**
+     * Push a trace to the traces array.
+     *
+     * @param \Enlightn\Enlightn\Analyzers\Trace $trace
+     * @return $this
+     */
+    public function pushTrace(Trace $trace)
+    {
+        if (! in_array($trace, $this->traces)) {
+            $this->traces[] = $trace;
         }
 
         return $this->markFailed();
@@ -166,22 +178,6 @@ abstract class Analyzer
         $this->exceptionMessage = $message;
 
         return $this->markSkipped();
-    }
-
-    /**
-     * Add an associated path and line numbers.
-     *
-     * @param  string  $path
-     * @param  array  $lineNumbers
-     * @return $this
-     */
-    public function addTraces(string $path, $lineNumbers = [])
-    {
-        collect($lineNumbers)->each(function ($lineNumber) use ($path) {
-            $this->addTrace($path, $lineNumber);
-        });
-
-        return $this;
     }
 
     /**

--- a/src/Analyzers/Concerns/InspectsCode.php
+++ b/src/Analyzers/Concerns/InspectsCode.php
@@ -30,8 +30,8 @@ trait InspectsCode
     protected function inspectCode(Inspector $inspector, QueryBuilder $builder)
     {
         if (! $this->passesCodeInspection($inspector, $builder)) {
-            collect($inspector->getLastErrors())->each(function ($lineNumbers, $path) {
-                $this->addTraces($path, $lineNumbers);
+            collect($inspector->getLastErrors())->each(function ($trace) {
+                $this->pushTrace($trace);
             });
 
             // Although adding traces would also mark it as failed, but there may be no traces

--- a/src/Analyzers/Concerns/ParsesPHPStanAnalysis.php
+++ b/src/Analyzers/Concerns/ParsesPHPStanAnalysis.php
@@ -2,6 +2,7 @@
 
 namespace Enlightn\Enlightn\Analyzers\Concerns;
 
+use Enlightn\Enlightn\Analyzers\Trace;
 use Enlightn\Enlightn\PHPStan;
 
 trait ParsesPHPStanAnalysis
@@ -14,8 +15,8 @@ trait ParsesPHPStanAnalysis
      */
     protected function parsePHPStanAnalysis(PHPStan $phpStan, $search)
     {
-        collect($phpStan->parseAnalysis($search))->each(function ($lineNumbers, $path) {
-            $this->addTraces($path, $lineNumbers);
+        collect($phpStan->parseAnalysis($search))->each(function (Trace $trace) {
+            $this->addTrace($trace->path, $trace->lineNumber, $trace->details);
         });
     }
 
@@ -27,8 +28,8 @@ trait ParsesPHPStanAnalysis
      */
     protected function matchPHPStanAnalysis(PHPStan $phpStan, $pattern)
     {
-        collect($phpStan->match($pattern))->each(function ($lineNumbers, $path) {
-            $this->addTraces($path, $lineNumbers);
+        collect($phpStan->match($pattern))->each(function (Trace $trace) {
+            $this->addTrace($trace->path, $trace->lineNumber, $trace->details);
         });
     }
 }

--- a/src/Analyzers/Reliability/SyntaxErrorAnalyzer.php
+++ b/src/Analyzers/Reliability/SyntaxErrorAnalyzer.php
@@ -49,7 +49,9 @@ class SyntaxErrorAnalyzer extends ReliabilityAnalyzer
             $this->markFailed();
 
             foreach ($inspector->errors as $path => $lineNumbers) {
-                $this->addTraces($path, $lineNumbers);
+                foreach ($lineNumbers as $lineNumber) {
+                    $this->addTrace($path, $lineNumber);
+                }
             }
         }
     }

--- a/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
+++ b/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
@@ -49,6 +49,6 @@ class FillableForeignKeyAnalyzer extends SecurityAnalyzer
      */
     public function handle(PHPStan $phpStan)
     {
-        $this->parsePHPStanAnalysis($phpStan, 'foreign key declared as fillable');
+        $this->parsePHPStanAnalysis($phpStan, 'declared as fillable');
     }
 }

--- a/src/Analyzers/Trace.php
+++ b/src/Analyzers/Trace.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Enlightn\Enlightn\Analyzers;
+
+class Trace
+{
+    /**
+     * @var int
+     */
+    public $lineNumber;
+
+    /**
+     * @var string|null
+     */
+    public $details;
+
+    /**
+     * @var string|null
+     */
+    public $path;
+
+    public function __construct($path, $lineNumber, $details = null)
+    {
+        $this->path = $path;
+        $this->lineNumber = $lineNumber;
+        $this->details = $details;
+    }
+}

--- a/src/Console/EnlightnCommand.php
+++ b/src/Console/EnlightnCommand.php
@@ -2,11 +2,9 @@
 
 namespace Enlightn\Enlightn\Console;
 
+use Enlightn\Enlightn\Console\Formatters\ReportFormatter;
 use Enlightn\Enlightn\Enlightn;
 use Illuminate\Console\Command;
-use Illuminate\Support\Str;
-use Symfony\Component\Console\Formatter\OutputFormatterStyle;
-use Symfony\Component\Console\Helper\TableStyle;
 
 class EnlightnCommand extends Command
 {
@@ -17,6 +15,7 @@ class EnlightnCommand extends Command
      */
     protected $signature = 'enlightn
                             {analyzer?* : The analyzer class that you wish to run}
+                            {--details : Show details of each failed check}
                             {--ci : Run Enlightn in CI Mode}';
 
     /**
@@ -25,6 +24,13 @@ class EnlightnCommand extends Command
      * @var string
      */
     protected $description = 'Enlightn your application!';
+
+    /**
+     * The final result of the analysis.
+     *
+     * @var array
+     */
+    public $result = [];
 
     /**
      * The number of analyzers to run.
@@ -48,25 +54,9 @@ class EnlightnCommand extends Command
     protected $analyzerClasses;
 
     /**
-     * The category of the analyzers currently being run.
-     *
-     * @var string|null
+     * @var \Enlightn\Enlightn\Console\Formatters\Formatter
      */
-    protected $category = null;
-
-    /**
-     * The final result of the analysis.
-     *
-     * @var array
-     */
-    protected $result = [];
-
-    /**
-     * Indicates whether to limit the number of lines or files displayed in each check.
-     *
-     * @var bool
-     */
-    protected $compactLines;
+    protected $formatter;
 
     /**
      * Execute the console command.
@@ -78,10 +68,9 @@ class EnlightnCommand extends Command
     {
         $this->analyzerClasses = $this->argument('analyzer');
 
-        $this->setColors();
-        $this->line(require __DIR__.DIRECTORY_SEPARATOR.'logo.php');
-        $this->output->newLine();
-        $this->line('Please wait while Enlightn scans your code base...');
+        $this->formatter = new ReportFormatter;
+
+        $this->formatter->beforeAnalysis($this);
 
         if ($this->option('ci')) {
             Enlightn::filterAnalyzersForCI();
@@ -92,14 +81,11 @@ class EnlightnCommand extends Command
         $this->totalAnalyzers = Enlightn::totalAnalyzers();
         $this->countAnalyzers = 1;
         $this->initializeResult();
-        $this->compactLines = config('enlightn.compact_lines', true);
 
         Enlightn::using([$this, 'printAnalyzerOutput']);
         Enlightn::run($this->laravel);
 
-        if (empty($this->analyzerClasses)) {
-            $this->printReportCard();
-        }
+        $this->formatter->afterAnalysis($this, empty($this->analyzerClasses));
 
         // Exit with a non-zero exit code if there were failed checks to throw an error on CI environments
         return collect($this->result)->sum(function ($category) {
@@ -114,44 +100,12 @@ class EnlightnCommand extends Command
      */
     public function printAnalyzerOutput(array $info)
     {
-        if ($this->category !== $info['category']) {
-            $this->output->newLine();
-            $this->line('|------------------------------------------');
-            $this->line('| Running '.$info['category'].' Checks');
-            $this->line('|------------------------------------------');
-        }
+        $this->formatter->parseAnalyzerResult(
+            $this, $info, $this->countAnalyzers, $this->totalAnalyzers, empty($this->analyzerClasses)
+        );
 
-        $this->output->newLine();
-        $this->output->write("<fg=yellow>Check {$this->countAnalyzers}/{$this->totalAnalyzers}: </fg=yellow>");
-        $this->output->write($info['title']);
-        $this->line(' '.$this->getSymbolForStatus($info['status']));
         $this->updateResult($info);
 
-        if (! in_array($info['status'], ['passed', 'skipped'])) {
-            $error = $info['error'] ?? $info['exception'];
-            $this->line("<fg=red>{$error}</fg=red>");
-
-            if (! empty($info['traces'])) {
-                collect($info['traces'])->when(empty($this->analyzerClasses) && $this->compactLines, function($collection) {
-                    return $collection->take(5);
-                })->each(function ($lineNumbers, $path) {
-                    $this->line(
-                        "<fg=magenta>At ".Str::after($path, base_path()).(empty($lineNumbers) ? "" : ": line(s): ")
-                        .collect($lineNumbers)->join(', ', ' and ').".</fg=magenta>"
-                    );
-                });
-
-                if (count($info['traces']) > 5 && empty($this->analyzerClasses) && $this->compactLines) {
-                    $this->line("<fg=magenta>And "
-                        .(count($info['traces']) - 5)
-                        ."</fg=magenta> more file(s).");
-                }
-            }
-
-            $this->line("<fg=cyan>Documentation URL: <href={$info['docsUrl']}>{$info['docsUrl']}</></fg=cyan>");
-        }
-
-        $this->category = $info['category'];
         $this->countAnalyzers++;
     }
 
@@ -180,58 +134,6 @@ class EnlightnCommand extends Command
     /**
      * Update the result based on the analysis.
      *
-     * @return string
-     */
-    protected function printReportCard()
-    {
-        $this->output->newLine();
-
-        $this->output->title('Report Card');
-
-        $rightAlign = (new TableStyle())->setPadType(STR_PAD_LEFT);
-
-        $this->table(
-            array_merge(['Status'], Enlightn::$categories, ['Total']),
-            collect(['passed', 'failed', 'skipped', 'error'])->map(function ($status) {
-                return array_merge([$status === 'skipped' ? 'Not Applicable' : ucfirst($status)],
-                    collect(array_merge(Enlightn::$categories, ['Total']))->map(function ($category) use ($status) {
-                        return $this->formatResult($status, $category);
-                    })->toArray()
-                );
-            })->values()->toArray(),
-            'default',
-            ['default', $rightAlign, $rightAlign, $rightAlign, $rightAlign]
-        );
-    }
-
-    /**
-     * Get the result with percentage for each category.
-     *
-     * @param $status
-     * @param $category
-     * @return string
-     */
-    protected function formatResult($status, $category) {
-        $totalAnalyzersInCategory = (float) collect($this->result[$category])->filter(function($result, $status) {
-            return in_array($status, ['passed', 'failed', 'skipped', 'error']);
-        })->sum(function ($count) {
-            return $count;
-        });
-
-        if ($totalAnalyzersInCategory == 0) {
-            // Avoid division by zero.
-            $percentage = 0;
-        } else {
-            $percentage = round((float) $this->result[$category][$status] * 100 / $totalAnalyzersInCategory, 0);
-        }
-
-        return $this->result[$category][$status]
-            .str_pad(" ({$percentage}%)", 7, " ", STR_PAD_LEFT);
-    }
-
-    /**
-     * Update the result based on the analysis.
-     *
      * @param array $info
      * @return string
      */
@@ -243,49 +145,5 @@ class EnlightnCommand extends Command
             $this->result[$info['category']]['reported']++;
             $this->result['Total']['reported']++;
         }
-    }
-
-    /**
-     * Get the appropriate symbol for the status.
-     *
-     * @param string $status
-     * @return string
-     */
-    protected function getSymbolForStatus(string $status)
-    {
-        switch ($status) {
-            case 'passed':
-                return '<fg=green>Passed</fg=green>';
-            case 'failed':
-                return '<fg=red>Failed</fg=red>';
-            case 'skipped':
-                return '<fg=cyan>Not Applicable</fg=cyan>';
-            case 'error':
-                return '<fg=magenta>Exception</fg=magenta>';
-        }
-
-        return '';
-    }
-
-    /**
-     * Set the console colors for Enlightn's logo.
-     *
-     * @return void
-     */
-    protected function setColors()
-    {
-        collect([
-            'e' => 'green',
-            'n' => 'green',
-            'l' => 'green',
-            'i' => 'green',
-            'g' => 'green',
-            'h' => 'green',
-            't' => 'green',
-            'ns' => 'green',
-        ])->each(function ($color, $tag) {
-            $this->output->getFormatter()->setStyle($tag, new OutputFormatterStyle($color));
-        });
-
     }
 }

--- a/src/Console/Formatters/Formatter.php
+++ b/src/Console/Formatters/Formatter.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Enlightn\Enlightn\Console\Formatters;
+
+use Illuminate\Console\Command;
+
+interface Formatter
+{
+    /**
+     * Called before analysis for initialization or printing a greeting message.
+     *
+     * @param \Illuminate\Console\Command $command
+     * @return void
+     */
+    public function beforeAnalysis(Command $command);
+
+    /**
+     * Called for each analyzer with the result.
+     *
+     * @param \Illuminate\Console\Command $command
+     * @param array $result
+     * @param int $current
+     * @param int $total
+     * @param bool $allAnalyzers
+     * @return void
+     */
+    public function parseAnalyzerResult(Command $command, array $result, int $current, int $total, bool $allAnalyzers);
+
+    /**
+     * Called after analysis for printing the final output.
+     *
+     * @param \Illuminate\Console\Command $command
+     * @param bool $allAnalyzers
+     * @return void
+     */
+    public function afterAnalysis(Command $command, bool $allAnalyzers);
+}

--- a/src/Console/Formatters/ReportFormatter.php
+++ b/src/Console/Formatters/ReportFormatter.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Enlightn\Enlightn\Console\Formatters;
+
+use Enlightn\Enlightn\Analyzers\Trace;
+use Enlightn\Enlightn\Enlightn;
+use Illuminate\Console\Command;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Helper\TableStyle;
+
+class ReportFormatter implements Formatter
+{
+    /**
+     * The category of the analyzers currently being run.
+     *
+     * @var string|null
+     */
+    protected $category = null;
+
+    /**
+     * Indicates whether to limit the number of lines or files displayed in each check.
+     *
+     * @var bool
+     */
+    protected $compactLines;
+
+    /**
+     * Called before analysis for initialization or printing a greeting message.
+     *
+     * @param \Illuminate\Console\Command $command
+     * @return void
+     */
+    public function beforeAnalysis(Command $command)
+    {
+        $this->setColors($command->getOutput());
+        $command->line(require __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'logo.php');
+        $command->getOutput()->newLine();
+        $command->line('Please wait while Enlightn scans your code base...');
+
+        $this->compactLines = config('enlightn.compact_lines', true);
+    }
+
+    /**
+     * Called for each analyzer with the result.
+     *
+     * @param \Illuminate\Console\Command $command
+     * @param array $result
+     * @param int $current
+     * @param int $total
+     * @param bool $allAnalyzers
+     * @return void
+     */
+    public function parseAnalyzerResult(Command $command, array $result, int $current, int $total, bool $allAnalyzers)
+    {
+        if ($this->category !== $result['category']) {
+            $command->getOutput()->newLine();
+            $command->line('|------------------------------------------');
+            $command->line('| Running '.$result['category'].' Checks');
+            $command->line('|------------------------------------------');
+        }
+
+        $command->getOutput()->newLine();
+        $command->getOutput()->write("<fg=yellow>Check {$current}/{$total}: </fg=yellow>");
+        $command->getOutput()->write($result['title']);
+        $command->line(' '.$this->getSymbolForStatus($result['status']));
+
+        if (! in_array($result['status'], ['passed', 'skipped'])) {
+            $error = $result['error'] ?? $result['exception'];
+            $command->line("<fg=red>{$error}</fg=red>");
+
+            if (! empty($result['traces'])) {
+                $this->formatTraces($command, $result['traces'], $allAnalyzers);
+            }
+
+            $command->line("<fg=cyan>Documentation URL: <href={$result['docsUrl']}>{$result['docsUrl']}</></fg=cyan>");
+        }
+
+        $this->category = $result['category'];
+    }
+
+    /**
+     * Called after analysis for printing the final output.
+     *
+     * @param \Illuminate\Console\Command $command
+     * @param bool $allAnalyzers
+     * @return void
+     */
+    public function afterAnalysis(Command $command, bool $allAnalyzers)
+    {
+        if ($allAnalyzers) {
+            $this->printReportCard($command);
+        }
+    }
+
+    /**
+     * @param \Illuminate\Console\Command $command
+     * @param array $traces
+     * @param bool $allAnalyzers
+     */
+    protected function formatTraces(Command $command, array $traces, bool $allAnalyzers)
+    {
+        if ($command->option('details')) {
+            collect($traces)->each(function (Trace $trace) use ($command) {
+               $command->line(
+                   "<fg=magenta>At ".Str::after($trace->path, base_path()).", line ".$trace->lineNumber
+                   .(is_null($trace->details) ? "." : (": ".$trace->details))."</fg=magenta>"
+               );
+            });
+
+            return;
+        }
+
+        collect($traces)->groupBy(function ($trace) {
+            return $trace->path;
+        })->when($allAnalyzers && $this->compactLines, function($collection) {
+            return $collection->take(5);
+        })->each(function ($traces, $path) use ($command) {
+            $lineNumbers = collect($traces)->map(function (Trace $trace) {
+                return $trace->lineNumber;
+            })->toArray();
+
+            $command->line(
+                "<fg=magenta>At ".Str::after($path, base_path()).(empty($lineNumbers) ? "" : ": line(s): ")
+                .collect($lineNumbers)->join(', ', ' and ').".</fg=magenta>"
+            );
+        });
+
+        $count = collect($traces)->groupBy(function ($trace) {
+            return $trace->path;
+        })->count();
+
+        if ($count > 5 && $allAnalyzers && $this->compactLines) {
+            $command->line("<fg=magenta>And "
+                .($count - 5)
+                ."</fg=magenta> more file(s).");
+        }
+    }
+
+    /**
+     * Update the result based on the analysis.
+     *
+     * @param \Illuminate\Console\Command $command
+     * @return string
+     */
+    protected function printReportCard(Command $command)
+    {
+        $command->getOutput()->newLine();
+
+        $command->getOutput()->title('Report Card');
+
+        $rightAlign = (new TableStyle())->setPadType(STR_PAD_LEFT);
+
+        $command->table(
+            array_merge(['Status'], Enlightn::$categories, ['Total']),
+            collect(['passed', 'failed', 'skipped', 'error'])->map(function ($status) use ($command) {
+                return array_merge([$status === 'skipped' ? 'Not Applicable' : ucfirst($status)],
+                    collect(array_merge(Enlightn::$categories, ['Total']))->map(function ($category) use ($status, $command) {
+                        return $this->formatResult($status, $category, $command->result);
+                    })->toArray()
+                );
+            })->values()->toArray(),
+            'default',
+            ['default', $rightAlign, $rightAlign, $rightAlign, $rightAlign]
+        );
+    }
+
+    /**
+     * Get the result with percentage for each category.
+     *
+     * @param string $status
+     * @param string $category
+     * @param array $result
+     * @return string
+     */
+    protected function formatResult(string $status, string $category, array $result) {
+        $totalAnalyzersInCategory = (float) collect($result[$category])->filter(function($_, $status) {
+            return in_array($status, ['passed', 'failed', 'skipped', 'error']);
+        })->sum(function ($count) {
+            return $count;
+        });
+
+        if ($totalAnalyzersInCategory == 0) {
+            // Avoid division by zero.
+            $percentage = 0;
+        } else {
+            $percentage = round((float) $result[$category][$status] * 100 / $totalAnalyzersInCategory, 0);
+        }
+
+        return $result[$category][$status]
+            .str_pad(" ({$percentage}%)", 7, " ", STR_PAD_LEFT);
+    }
+
+    /**
+     * Set the console colors for Enlightn's logo.
+     *
+     * @param \Illuminate\Console\OutputStyle $output
+     * @return void
+     */
+    protected function setColors(OutputStyle $output)
+    {
+        collect([
+            'e' => 'green',
+            'n' => 'green',
+            'l' => 'green',
+            'i' => 'green',
+            'g' => 'green',
+            'h' => 'green',
+            't' => 'green',
+            'ns' => 'green',
+        ])->each(function ($color, $tag) use ($output) {
+            $output->getFormatter()->setStyle($tag, new OutputFormatterStyle($color));
+        });
+    }
+
+    /**
+     * Get the appropriate symbol for the status.
+     *
+     * @param string $status
+     * @return string
+     */
+    protected function getSymbolForStatus(string $status)
+    {
+        switch ($status) {
+            case 'passed':
+                return '<fg=green>Passed</fg=green>';
+            case 'failed':
+                return '<fg=red>Failed</fg=red>';
+            case 'skipped':
+                return '<fg=cyan>Not Applicable</fg=cyan>';
+            case 'error':
+                return '<fg=magenta>Exception</fg=magenta>';
+        }
+
+        return '';
+    }
+}

--- a/src/Inspection/InspectionLine.php
+++ b/src/Inspection/InspectionLine.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Enlightn\Enlightn\Inspection;
+
+class InspectionLine
+{
+    /**
+     * @var int
+     */
+    public $lineNumber;
+
+    /**
+     * @var string|null
+     */
+    public $details;
+
+    public function __construct($lineNumber, $details = null)
+    {
+        $this->lineNumber = $lineNumber;
+        $this->details = $details;
+    }
+}

--- a/src/Inspection/NodeVisitors/ClassInstantiationVisitor.php
+++ b/src/Inspection/NodeVisitors/ClassInstantiationVisitor.php
@@ -31,7 +31,7 @@ class ClassInstantiationVisitor extends NodeVisitor
                 $this->compareArguments($node->args, $this->parameters)) {
                 // Here, we register the new Alias(...) or the new ClassName(...) call.
                 // This also works without the use import, such as new \Fully\Qualified\ClassName().
-                $this->recordLineNumbers($node);
+                $this->recordLineNumbers($node, "Instance of {$this->class} class instantiated.");
             }
         }
 

--- a/src/Inspection/NodeVisitors/EvalExpressionVisitor.php
+++ b/src/Inspection/NodeVisitors/EvalExpressionVisitor.php
@@ -14,7 +14,7 @@ class EvalExpressionVisitor extends NodeVisitor
     public function enterNode(Node $node)
     {
         if ($node instanceof Node\Expr\Eval_) {
-            $this->recordLineNumbers($node);
+            $this->recordLineNumbers($node, "Eval statement detected.");
         }
 
         return null;

--- a/src/Inspection/NodeVisitors/ExitStatementVisitor.php
+++ b/src/Inspection/NodeVisitors/ExitStatementVisitor.php
@@ -14,7 +14,7 @@ class ExitStatementVisitor extends NodeVisitor
     public function enterNode(Node $node)
     {
         if ($node instanceof Node\Expr\Exit_) {
-            $this->recordLineNumbers($node);
+            $this->recordLineNumbers($node, "Exit statement detected.");
         }
 
         return null;

--- a/src/Inspection/NodeVisitors/FunctionCallVisitor.php
+++ b/src/Inspection/NodeVisitors/FunctionCallVisitor.php
@@ -23,7 +23,7 @@ class FunctionCallVisitor extends NodeVisitor
             && $node->name->toString() === $this->functionName) {
             if (empty($this->parameters) ||
                 $this->compareArguments($node->args, $this->parameters)) {
-                $this->recordLineNumbers($node);
+                $this->recordLineNumbers($node, "Function {$this->functionName} called.");
             }
         }
 

--- a/src/Inspection/NodeVisitors/GlobalStatementVisitor.php
+++ b/src/Inspection/NodeVisitors/GlobalStatementVisitor.php
@@ -14,7 +14,7 @@ class GlobalStatementVisitor extends NodeVisitor
     public function enterNode(Node $node)
     {
         if ($node instanceof Node\Stmt\Global_) {
-            $this->recordLineNumbers($node);
+            $this->recordLineNumbers($node, "Global statement detected.");
         }
 
         return null;

--- a/src/Inspection/NodeVisitors/GlobalVariableVisitor.php
+++ b/src/Inspection/NodeVisitors/GlobalVariableVisitor.php
@@ -18,7 +18,7 @@ class GlobalVariableVisitor extends NodeVisitor
     {
         if ($node instanceof Node\Expr\Variable
             && $node->name === $this->variableName) {
-            $this->recordLineNumbers($node);
+            $this->recordLineNumbers($node, "Global variable {$this->variableName} detected.");
         }
 
         return null;

--- a/src/Inspection/NodeVisitors/NodeVisitor.php
+++ b/src/Inspection/NodeVisitors/NodeVisitor.php
@@ -2,6 +2,7 @@
 
 namespace Enlightn\Enlightn\Inspection\NodeVisitors;
 
+use Enlightn\Enlightn\Inspection\InspectionLine;
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ConstFetch;
@@ -72,13 +73,15 @@ abstract class NodeVisitor extends NodeVisitorAbstract implements VisitorContrac
     /**
      * Record the line numbers based on the node.
      *
+     * @param $node
+     * @param string|null $details
      * @return $this
      */
-    protected function recordLineNumbers($node)
+    protected function recordLineNumbers($node, $details = null)
     {
         $this->markFound();
 
-        $this->lineNumbers[] = $node->getStartLine();
+        $this->lineNumbers[] = new InspectionLine($node->getStartLine(), $details);
 
         return $this;
     }

--- a/src/Inspection/NodeVisitors/StaticMethodCallVisitor.php
+++ b/src/Inspection/NodeVisitors/StaticMethodCallVisitor.php
@@ -35,7 +35,7 @@ class StaticMethodCallVisitor extends NodeVisitor
             && $node->name->name === $this->methodName) {
             if (empty($this->parameters) ||
                 $this->compareArguments($node->args, $this->parameters)) {
-                $this->recordLineNumbers($node);
+                $this->recordLineNumbers($node, "Static method {$this->methodName} detected on class {$this->class}.");
 
                 return null;
             }

--- a/src/Inspection/NodeVisitors/UsesClassVisitor.php
+++ b/src/Inspection/NodeVisitors/UsesClassVisitor.php
@@ -21,7 +21,7 @@ class UsesClassVisitor extends NodeVisitor
             && ($node->name->toString() === $this->class
                 || is_subclass_of($node->name->toString(), $this->class))) {
             // Here we register a use ClassName or use ChildClass statement.
-            $this->recordLineNumbers($node);
+            $this->recordLineNumbers($node, "Import of class {$this->class} detected.");
         }
 
         return null;

--- a/src/PHPStan.php
+++ b/src/PHPStan.php
@@ -2,6 +2,7 @@
 
 namespace Enlightn\Enlightn;
 
+use Enlightn\Enlightn\Analyzers\Trace;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ProcessUtils;
@@ -64,13 +65,13 @@ class PHPStan
             return [];
         }
 
-        return collect($this->result['files'])->map(function ($fileAnalysis) use ($search) {
+        return collect($this->result['files'])->map(function ($fileAnalysis, $path) use ($search) {
             return collect($fileAnalysis['messages'])->filter(function ($message) use ($search) {
                 return Str::contains($message['message'], $search);
-            })->map(function ($message) {
-                return $message['line'];
+            })->map(function ($message) use ($path) {
+                return new Trace($path, $message['line'], $message['message']);
             })->flatten()->toArray();
-        })->filter()->toArray();
+        })->filter()->flatten()->toArray();
     }
 
     /**
@@ -85,13 +86,13 @@ class PHPStan
             return [];
         }
 
-        return collect($this->result['files'])->map(function ($fileAnalysis) use ($pattern) {
+        return collect($this->result['files'])->map(function ($fileAnalysis, $path) use ($pattern) {
             return collect($fileAnalysis['messages'])->filter(function ($message) use ($pattern) {
                 return Str::is($pattern, $message['message']);
-            })->map(function ($message) {
-                return $message['line'];
+            })->map(function ($message) use ($path) {
+                return new Trace($path, $message['line'], $message['message']);
             })->flatten()->toArray();
-        })->filter()->toArray();
+        })->filter()->flatten()->toArray();
     }
 
     /**

--- a/src/PHPStan/FillableForeignKeyModelRule.php
+++ b/src/PHPStan/FillableForeignKeyModelRule.php
@@ -34,7 +34,7 @@ class FillableForeignKeyModelRule implements Rule
             return [];
         }
 
-        if (! is_subclass_of($scope->getClassReflection()->getName(), Model::class)) {
+        if (! is_subclass_of($modelClass = $scope->getClassReflection()->getName(), Model::class)) {
             // We are only looking for Model classes.
             return [];
         }
@@ -49,8 +49,13 @@ class FillableForeignKeyModelRule implements Rule
             }
 
             if ($item->value instanceof Node\Scalar\String_
-                && Str::contains($item->value->value, '_id')) {
-                return ['Potential foreign key declared as fillable and available for mass assignment.'];
+                && Str::contains($key = $item->value->value, '_id')) {
+                return [
+                    sprintf(
+                        'Potential foreign key %s declared as fillable and available for mass assignment.',
+                        $key
+                    )
+                ];
             }
         }
 

--- a/src/PHPStan/MassAssignmentBuilderInstanceRule.php
+++ b/src/PHPStan/MassAssignmentBuilderInstanceRule.php
@@ -27,7 +27,7 @@ class MassAssignmentBuilderInstanceRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         if (! $node->name instanceof Node\Identifier
-            || ! in_array($node->name->toString(), [
+            || ! in_array($methodName = $node->name->toString(), [
                 'update', 'insert', 'upsert', 'insertOrIgnore', 'insertUsing', 'insertGetId', 'updateOrInsert',
             ])) {
             // Method name must match blacklisted names.
@@ -40,9 +40,13 @@ class MassAssignmentBuilderInstanceRule implements Rule
         }
 
         if (isset($node->args[0]) && $this->retrievesRequestInput($node->args[0], $scope)) {
-            return ["All request data should not be saved to the database. This may result in a mass assignment "
-                ."vulnerability which overwrites database fields that were never intended to be modified. "
-                ."Use the Request object's only or validated methods instead."];
+            return [
+                sprintf(
+                    "Call to %s method on an Eloquent/query builder instance with request data may result in a "
+                    ."mass assignment vulnerability.",
+                    $methodName
+                )
+            ];
         }
 
         return [];

--- a/src/PHPStan/MassAssignmentModelInstanceRule.php
+++ b/src/PHPStan/MassAssignmentModelInstanceRule.php
@@ -28,7 +28,7 @@ class MassAssignmentModelInstanceRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         if (! $node->name instanceof Node\Identifier
-            || ! in_array($node->name->toString(), ['forceFill', 'fill', 'update'])) {
+            || ! in_array($methodName = $node->name->toString(), ['forceFill', 'fill', 'update'])) {
             // We are only looking for fill(...) or forceFill(...) method calls
             return [];
         }
@@ -39,9 +39,13 @@ class MassAssignmentModelInstanceRule implements Rule
         }
 
         if (isset($node->args[0]) && $this->retrievesRequestInput($node->args[0], $scope)) {
-            return ["All request data should not be saved to a model. This may result in a mass assignment "
-                ."vulnerability which overwrites database fields that were never intended to be modified. "
-                ."Use the Request object's only or validated methods instead."];
+            return [
+                sprintf(
+                    "Call to %s method on a Model instance with request data may result in a "
+                    ."mass assignment vulnerability.",
+                    $methodName
+                )
+            ];
         }
 
         return [];

--- a/src/PHPStan/MassAssignmentModelStaticRule.php
+++ b/src/PHPStan/MassAssignmentModelStaticRule.php
@@ -43,7 +43,7 @@ class MassAssignmentModelStaticRule implements Rule
             return [];
         }
 
-        if (! in_array($node->name->toString(), [
+        if (! in_array($methodName = $node->name->toString(), [
             'create', 'forceCreate', 'firstOrCreate', 'updateOrCreate', 'insert', 'upsert',
             'update', 'insertOrIgnore', 'make', 'firstOrNew',
         ])) {
@@ -51,9 +51,13 @@ class MassAssignmentModelStaticRule implements Rule
         }
 
         if (isset($node->args[0]) && $this->retrievesRequestInput($node->args[0], $scope)) {
-            return ["All request data should not be saved to the database. This may result in a mass assignment "
-                ."vulnerability which overwrites database fields that were never intended to be modified. "
-                ."Use the Request object's only or validated methods instead."];
+            return [
+                sprintf(
+                    "Static call to %s method on a Model class with request data may result in a "
+                    ."mass assignment vulnerability.",
+                    $methodName
+                )
+            ];
         }
 
         return [];

--- a/tests/Analyzers/Reliability/InvalidOffsetAnalyzerTest.php
+++ b/tests/Analyzers/Reliability/InvalidOffsetAnalyzerTest.php
@@ -29,7 +29,7 @@ class InvalidOffsetAnalyzerTest extends AnalyzerTestCase
         $this->assertFailedAt(InvalidOffsetAnalyzer::class, $this->getClassStubPath(InvalidOffsetStub::class), 13);
         $this->assertFailedAt(InvalidOffsetAnalyzer::class, $this->getClassStubPath(InvalidOffsetStub::class), 17);
         $this->assertFailedAt(InvalidOffsetAnalyzer::class, $this->getClassStubPath(InvalidOffsetStub::class), 25);
-        $this->assertHasErrors(InvalidOffsetAnalyzer::class, 4);
+        $this->assertHasErrors(InvalidOffsetAnalyzer::class, 5);
     }
 
     /**

--- a/tests/Analyzers/Reliability/UnsetAnalyzerTest.php
+++ b/tests/Analyzers/Reliability/UnsetAnalyzerTest.php
@@ -30,7 +30,7 @@ class UnsetAnalyzerTest extends AnalyzerTestCase
         $this->assertFailedAt(UnsetAnalyzer::class, $this->getClassStubPath(UnsetStub::class), 13);
         $this->assertFailedAt(UnsetAnalyzer::class, $this->getClassStubPath(UnsetStub::class), 16);
         $this->assertFailedAt(UnsetAnalyzer::class, $this->getClassStubPath(UnsetStub::class), 19);
-        $this->assertHasErrors(UnsetAnalyzer::class, 5);
+        $this->assertHasErrors(UnsetAnalyzer::class, 6);
     }
 
     /**


### PR DESCRIPTION
This PR introduces more detailed analyzer fail messages for easier identification of the issues flagged. Error messages (whether from PHPStan or Enlightn's own static analysis inspector) will now contain details of exactly what is wrong at the given file and line number, and also provide the ability to ignore error messages.

This PR will contain:
- [x] Ability to add details along with the file and line number.
- [x] Change Enlightn command for new format of error messages.
- [x] Add an Enlightn formatter class for flexibility in format.
- [x] Introduce a `--details` flag in the Enlightn command to get more detailed messages.
- [x] Add specific detail messages for the individual analyzers.

There will be another follow up PR for ignoring error messages.