### PR TITLE
Add ability to ignore errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,24 @@ Enlightn pre-configures which analyzers can be run in CI mode for you. So, the a
 
 For more information on CI integration, refer the [Enlightn documentation](https://www.laravel-enlightn.com/docs/getting-started/usage.html#usage-in-ci-environments).
 
+## Establishing a Baseline
+
+Sometimes, especially in CI environments, you may want to declare the currently reported list of errors as the "baseline". This means that the current errors will not be reported in subsequent runs and only new errors will be flagged.
+
+To generate the baseline automatically, you may run the `enlightn:baseline` Artisan command:
+
+```bash
+php artisan enlightn:baseline
+```
+
+If you wish to run this command in CI mode, you can use the `--ci` option:
+
+```bash
+php artisan enlightn:baseline --ci
+```
+
+For more information on establishing a baseline, refer [the docs](https://www.laravel-enlightn.com/docs/getting-started/usage.html#establishing-a-baseline).
+
 ## Failed Checks
 
 All checks that fail will include a description of why they failed along with the associated lines of code (if applicable) and a link to the documentation for the specific check.

--- a/composer.json
+++ b/composer.json
@@ -60,8 +60,7 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/phpunit --colors=always",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
+        "test": "vendor/bin/paratest --colors"
     },
     "config": {
         "sort-packages": true

--- a/config/enlightn.php
+++ b/config/enlightn.php
@@ -92,6 +92,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Ignoring Errors
+    |--------------------------------------------------------------------------
+    |
+    | Use this config option to ignore specific errors. The key of this array
+    | would be the analyzer class and the value would be an associative
+    | array with path and details. Run php artisan enlightn:baseline
+    | to auto-generate this. Patterns are supported in details.
+    |
+    */
+    'ignore_errors' => [],
+
+    /*
+    |--------------------------------------------------------------------------
     | Analyzer Configurations
     |--------------------------------------------------------------------------
     |

--- a/src/Analyzers/Analyzer.php
+++ b/src/Analyzers/Analyzer.php
@@ -152,6 +152,10 @@ abstract class Analyzer
      */
     public function pushTrace(Trace $trace)
     {
+        if ($this->isIgnoredError($trace->path, $trace->details)) {
+            return $this;
+        }
+
         if (! in_array($trace, $this->traces)) {
             $this->traces[] = $trace;
         }

--- a/src/Analyzers/Analyzer.php
+++ b/src/Analyzers/Analyzer.php
@@ -230,6 +230,7 @@ abstract class Analyzer
             'traces' => $this->traces,
             'docsUrl' => $this->getDocsUrl(),
             'reportable' => ! in_array(static::class, config('enlightn.dont_report', [])),
+            'class' => static::class,
         ];
     }
 

--- a/src/Analyzers/Concerns/InspectsCode.php
+++ b/src/Analyzers/Concerns/InspectsCode.php
@@ -36,7 +36,9 @@ trait InspectsCode
 
             // Although adding traces would also mark it as failed, but there may be no traces
             // at all, yet should still be failed.
-            $this->markFailed();
+            if (empty($inspector->getLastErrors())) {
+                $this->markFailed();
+            }
         }
     }
 }

--- a/src/CodeCorrection/ConfigManipulator.php
+++ b/src/CodeCorrection/ConfigManipulator.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Enlightn\Enlightn\CodeCorrection;
+
+use Illuminate\Filesystem\Filesystem;
+use PhpParser\Lexer\Emulative;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\CloningVisitor;
+use PhpParser\Parser\Php7;
+use PhpParser\PrettyPrinter\Standard;
+
+class ConfigManipulator
+{
+    use ConstructsConfigurationAST;
+
+    /**
+     * Get the config values as pretty printed code.
+     *
+     * @param array $configValues
+     * @return string
+     */
+    public function get($configValues = [])
+    {
+        $items = [];
+
+        foreach ($configValues as $key => $configValue) {
+            $items[] = new ArrayItem(
+                $this->getConfiguration($configValue),
+                new String_($key)
+            );
+        }
+
+        $ast = [new Array_($items)];
+
+        return (new Standard(['shortArraySyntax' => true]))->prettyPrint($ast);
+    }
+
+    /**
+     * Modify the config file with the given config values.
+     *
+     * @param string $configFilePath
+     * @param array $configValues
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    public function replace(string $configFilePath, $configValues = [])
+    {
+        $lexer = new Emulative([
+            'usedAttributes' => [
+                'comments',
+                'startLine', 'endLine',
+                'startTokenPos', 'endTokenPos',
+            ],
+        ]);
+        $parser = new Php7($lexer);
+
+        $ast = $parser->parse((new Filesystem)->get($configFilePath));
+        $oldTokens = $lexer->getTokens();
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor(new CloningVisitor);
+
+        $config = require $configFilePath;
+
+        foreach ($configValues as $key => $configValue) {
+            if (isset($config[$key])) {
+                $traverser->addVisitor(new ConfigReplacementNodeVisitor($key, $configValue));
+            }
+        }
+
+        $newAst = $traverser->traverse($ast);
+
+        foreach ($configValues as $key => $configValue) {
+            if (! isset($config[$key])
+                && isset($newAst[0])
+                && $newAst[0] instanceof Return_
+                && $newAst[0]->expr instanceof Array_) {
+
+                $newAst[0]->expr->items[] = new ArrayItem(
+                    $this->getConfiguration($configValue),
+                    new String_($key)
+                );
+            }
+        }
+
+        $newCode = (new Standard(['shortArraySyntax' => true]))->printFormatPreserving($newAst, $ast, $oldTokens);
+
+        (new Filesystem)->put($configFilePath, $newCode);
+    }
+}

--- a/src/CodeCorrection/ConfigReplacementNodeVisitor.php
+++ b/src/CodeCorrection/ConfigReplacementNodeVisitor.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Enlightn\Enlightn\CodeCorrection;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+
+class ConfigReplacementNodeVisitor extends NodeVisitorAbstract
+{
+    use ConstructsConfigurationAST;
+
+    /**
+     * @var string
+     */
+    protected $configKey;
+
+    /**
+     * @var string|array
+     */
+    protected $configValue;
+
+    public function __construct($configKey = null, $configValue = null)
+    {
+        $this->configKey = $configKey;
+        $this->configValue = $configValue;
+    }
+
+    public function leaveNode(Node $node) {
+        if ($node instanceof Node\Expr\ArrayItem
+            && $node->key instanceof Node\Scalar\String_
+            && $node->key->value === $this->configKey) {
+
+            $node->value = $this->getConfiguration($this->configValue);
+        }
+    }
+}

--- a/src/CodeCorrection/ConstructsConfigurationAST.php
+++ b/src/CodeCorrection/ConstructsConfigurationAST.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Enlightn\Enlightn\CodeCorrection;
+
+use Illuminate\Support\Str;
+use PhpParser\Node;
+
+trait ConstructsConfigurationAST
+{
+    /**
+     * Only supports arrays or strings.
+     *
+     * @param $value
+     * @return \PhpParser\Node\Expr\Array_|\PhpParser\Node\Expr\ClassConstFetch|\PhpParser\Node\Scalar\String_
+     */
+    public function getConfiguration($value)
+    {
+        if (is_string($value)) {
+            if (Str::contains($value, '\\') && class_exists($value)) {
+                return new Node\Expr\ClassConstFetch(new Node\Name($value), new Node\Identifier('class'));
+            }
+
+            return new Node\Scalar\String_($value);
+        } elseif (is_array($value)) {
+            $items = [];
+            foreach ($value as $arrayKey => $arrayValue) {
+                if (is_string($arrayKey)) {
+                    // Assuming associative array.
+                    $items[] = new Node\Expr\ArrayItem($this->getConfiguration($arrayValue), $this->getConfiguration($arrayKey));
+                } else {
+                    // Assuming sequential array.
+                    $items[] = new Node\Expr\ArrayItem($this->getConfiguration($arrayValue), null);
+                }
+            }
+            return new Node\Expr\Array_($items);
+        }
+    }
+}

--- a/src/Console/BaselineCommand.php
+++ b/src/Console/BaselineCommand.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Enlightn\Enlightn\Console;
+
+use Enlightn\Enlightn\Analyzers\Trace;
+use Enlightn\Enlightn\CodeCorrection\ConfigManipulator;
+use Enlightn\Enlightn\Enlightn;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+
+class BaselineCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'enlightn:baseline
+                            {--ci : Run Enlightn in CI Mode}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Declare the currently reported errors as the baseline to avoid reporting them in subsequent runs.';
+
+    /**
+     * @var array
+     */
+    protected $dont_report = [];
+
+    /**
+     * @var array
+     */
+    protected $ignore_errors = [];
+
+    /**
+     * @var \Symfony\Component\Console\Helper\ProgressBar
+     */
+    protected $progressbar;
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     * @throws \ReflectionException|\Illuminate\Contracts\Container\BindingResolutionException|\Throwable
+     */
+    public function handle()
+    {
+        $this->setColors();
+        $this->line(require __DIR__.DIRECTORY_SEPARATOR.'logo.php');
+        $this->output->newLine();
+        $this->line('Please wait while Enlightn scans your code base...');
+        $this->output->newLine();
+
+        // Reset ignored errors to establish a complete baseline.
+        config()->set('enlightn.ignore_errors', []);
+
+        if ($this->option('ci')) {
+            Enlightn::filterAnalyzersForCI();
+        }
+
+        Enlightn::register();
+
+        $this->progressbar = $this->output->createProgressBar(count(Enlightn::$analyzerClasses));
+
+        Enlightn::using([$this, 'parseAnalyzerResult']);
+        Enlightn::run($this->laravel);
+
+        $this->progressbar->finish();
+        $this->output->newLine();
+
+        $this->updateConfig();
+
+        return 0;
+    }
+
+    /**
+     * Parse the result of each analyzer.
+     *
+     * @param array $info
+     * @return void
+     */
+    public function parseAnalyzerResult(array $info)
+    {
+        if ($info['status'] === 'failed' && empty($info['traces'])) {
+            $this->dont_report[] = $info['class'];
+        }
+
+        if (empty($info['traces'])) {
+            return;
+        }
+
+        collect($info['traces'])->each(function (Trace $trace) use ($info) {
+            if (is_null($trace->details)) {
+                if (! in_array($info['class'], $this->dont_report)) {
+                    $this->dont_report[] = $info['class'];
+                }
+            } else {
+                if (! isset($this->ignore_errors[$info['class']])) {
+                    $this->ignore_errors[$info['class']] = [];
+                }
+
+                $this->ignore_errors[$info['class']][] = [
+                    'path' => Str::contains($trace->path, base_path()) ?
+                        trim(Str::after($trace->path, base_path()), '/') : $trace->path,
+                    'details' => $trace->details,
+                ];
+            }
+        });
+
+        $this->progressbar->advance();
+    }
+
+    /**
+     * Update the config file for new baseline.
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    protected function updateConfig()
+    {
+        if (! file_exists(config_path('enlightn.php'))) {
+            if (Enlightn::isPro()) {
+                $this->call('vendor:publish', ['--tag' => 'enlightnpro']);
+            } else {
+                $this->call('vendor:publish', ['--tag' => 'enlightn']);
+            }
+        }
+
+        (new ConfigManipulator)->replace(config_path('enlightn.php'), [
+            'dont_report' => $this->dont_report,
+            'ignore_errors' => $this->ignore_errors,
+        ]);
+
+        $this->info("Successfully updated config/enlightn.php with new baseline values.");
+    }
+
+    /**
+     * Set the console colors for Enlightn's logo.
+     *
+     * @return void
+     */
+    protected function setColors()
+    {
+        collect([
+            'e' => 'green',
+            'n' => 'green',
+            'l' => 'green',
+            'i' => 'green',
+            'g' => 'green',
+            'h' => 'green',
+            't' => 'green',
+            'ns' => 'green',
+        ])->each(function ($color, $tag) {
+            $this->output->getFormatter()->setStyle($tag, new OutputFormatterStyle($color));
+        });
+    }
+}

--- a/src/Enlightn.php
+++ b/src/Enlightn.php
@@ -109,6 +109,16 @@ class Enlightn
     }
 
     /**
+     * Determine if Enlightn Pro is installed.
+     *
+     * @return bool
+     */
+    public static function isPro()
+    {
+        return class_exists(\Enlightn\EnlightnPro\EnlightnProServiceProvider::class);
+    }
+
+    /**
      * Call the after callback on the analyzer.
      *
      * @param \Enlightn\Enlightn\Analyzers\Analyzer $analyzer

--- a/src/EnlightnServiceProvider.php
+++ b/src/EnlightnServiceProvider.php
@@ -30,6 +30,7 @@ class EnlightnServiceProvider extends ServiceProvider
     {
         $this->commands([
             Console\EnlightnCommand::class,
+            Console\BaselineCommand::class,
         ]);
 
         $this->mergeConfigFrom(__DIR__.'/../config/enlightn.php', 'enlightn');

--- a/tests/Analyzers/Performance/EnvCallAnalyzerTest.php
+++ b/tests/Analyzers/Performance/EnvCallAnalyzerTest.php
@@ -31,6 +31,24 @@ class EnvCallAnalyzerTest extends AnalyzerTestCase
     /**
      * @test
      */
+    public function ignores_errors()
+    {
+        $this->setBasePathFrom(EnvStub::class);
+        $this->app->config->set('enlightn.ignore_errors', [EnvCallAnalyzer::class => [
+            [
+                'path' => $this->getClassStubPath(EnvStub::class),
+                'details' => 'Function env called.',
+            ]
+        ]]);
+
+        $this->runEnlightn();
+
+        $this->assertPassed(EnvCallAnalyzer::class);
+    }
+
+    /**
+     * @test
+     */
     public function passes_with_no_env_call()
     {
         $this->setBasePathFrom(DummyStub::class);

--- a/tests/Analyzers/Reliability/InvalidMethodCallAnalyzerTest.php
+++ b/tests/Analyzers/Reliability/InvalidMethodCallAnalyzerTest.php
@@ -39,6 +39,30 @@ class InvalidMethodCallAnalyzerTest extends AnalyzerTestCase
     /**
      * @test
      */
+    public function ignores_errors()
+    {
+        $this->setBasePathFrom(InvalidMethodCallStub::class);
+        $this->app->config->set('enlightn.ignore_errors', [InvalidMethodCallAnalyzer::class => [
+            [
+                'path' => $this->getClassStubPath(InvalidMethodCallStub::class),
+                'details' => 'Call to an undefined method Enlightn\Enlightn\Tests\Stubs\InvalidMethodCallStub::protectedMethodFromChild().',
+            ],
+            [
+                'path' => $this->getClassStubPath(InvalidMethodCallStub::class),
+                'details' => '*undefined method Enlightn\Enlightn\Tests\Stubs\InvalidMethodCallStub::lorem*',
+            ]
+        ]]);
+
+        $this->runEnlightn();
+
+        $this->assertNotFailedAt(InvalidMethodCallAnalyzer::class, $this->getClassStubPath(InvalidMethodCallStub::class), 9);
+        $this->assertNotFailedAt(InvalidMethodCallAnalyzer::class, $this->getClassStubPath(InvalidMethodCallStub::class), 10);
+        $this->assertHasErrors(InvalidMethodCallAnalyzer::class, 6);
+    }
+
+    /**
+     * @test
+     */
     public function passes_with_no_invalid_method_calls()
     {
         $this->setBasePathFrom(DummyStub::class);


### PR DESCRIPTION
Follow-up to https://github.com/enlightn/enlightn/pull/32. This PR adds the ability to ignore errors by using the `ignore_errors` configuration option:

```php
'ignore_errors' => [
    InvalidMethodCallAnalyzer::class => [
        [
            'path' => 'app/Models/Test.php',
            'details' => '*undefined method*',
        ],
    ],
],
```

The `details` string supports patterns and exact string matches.

This PR contains:
- [x] Ability to ignore errors using the `ignore_errors` config option.
- [x] An Artisan command to baseline errors so that all existing errors are ignored (baseline is set). Any further errors beyond the baseline will then be reported.