### PR TITLE
Flush before running callback

### DIFF
--- a/src/Enlightn.php
+++ b/src/Enlightn.php
@@ -228,6 +228,8 @@ class Enlightn
         static::$afterCallback = null;
 
         static::$filterCallback = null;
+
+        static::$beforeRunningCallback = null;
     }
 
     /**


### PR DESCRIPTION
Leftover from https://github.com/enlightn/enlightn/pull/43. Although, the flush method is only used in tests, it's best to also flush the `beforeRunningCallback`.