### PR TITLE
Fix trusted proxies bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
     "require-dev": {
         "barryvdh/laravel-ide-helper": "^2.8",
         "brianium/paratest": "^6.1",
+        "fideloper/proxy": "^4.4",
         "friendsofphp/php-cs-fixer": "^2.18",
         "mockery/mockery": "^1.3",
         "orchestra/testbench": "^4.0|^5.0|^6.0",

--- a/src/Analyzers/Concerns/AnalyzesMiddleware.php
+++ b/src/Analyzers/Concerns/AnalyzesMiddleware.php
@@ -105,7 +105,6 @@ trait AnalyzesMiddleware
      * @param  \Illuminate\Routing\Route $route
      * @param  string  $middlewareClass
      * @return bool
-     * @throws \ReflectionException
      */
     protected function routeUsesMiddleware($route, string $middlewareClass)
     {

--- a/tests/Analyzers/Performance/UnusedGlobleMiddlewareAnalyzerTest.php
+++ b/tests/Analyzers/Performance/UnusedGlobleMiddlewareAnalyzerTest.php
@@ -5,6 +5,7 @@ namespace Enlightn\Enlightn\Tests\Analyzers\Performance;
 use Enlightn\Enlightn\Analyzers\Performance\UnusedGlobalMiddlewareAnalyzer;
 use Enlightn\Enlightn\Tests\Analyzers\AnalyzerTestCase;
 use Enlightn\Enlightn\Tests\Analyzers\Concerns\InteractsWithMiddleware;
+use Fideloper\Proxy\TrustProxies;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Middleware\TrustHosts;
 
@@ -40,4 +41,39 @@ class UnusedGlobleMiddlewareAnalyzerTest extends AnalyzerTestCase
 
         $this->assertFailed(UnusedGlobalMiddlewareAnalyzer::class);
     }
+
+    /**
+     * @test
+     */
+    public function passes_with_wildcard_trusted_proxies()
+    {
+        $this->app->make(Kernel::class)->pushMiddleware(DummyTrustProxies::class);
+
+        $this->runEnlightn();
+
+        $this->assertPassed(UnusedGlobalMiddlewareAnalyzer::class);
+    }
+
+    /**
+     * @test
+     */
+    public function detects_unused_trusted_proxies()
+    {
+        $this->app->make(Kernel::class)->pushMiddleware(UnusedTrustProxies::class);
+
+        $this->runEnlightn();
+
+        $this->assertFailed(UnusedGlobalMiddlewareAnalyzer::class);
+    }
 }
+
+class DummyTrustProxies extends TrustProxies {
+    /**
+     * The trusted proxies for the application.
+     *
+     * @var null|string|array
+     */
+    protected $proxies = '*';
+}
+
+class UnusedTrustProxies extends TrustProxies {}

--- a/tests/Analyzers/Performance/UnusedGlobleMiddlewareAnalyzerTest.php
+++ b/tests/Analyzers/Performance/UnusedGlobleMiddlewareAnalyzerTest.php
@@ -67,7 +67,8 @@ class UnusedGlobleMiddlewareAnalyzerTest extends AnalyzerTestCase
     }
 }
 
-class DummyTrustProxies extends TrustProxies {
+class DummyTrustProxies extends TrustProxies
+{
     /**
      * The trusted proxies for the application.
      *
@@ -76,4 +77,6 @@ class DummyTrustProxies extends TrustProxies {
     protected $proxies = '*';
 }
 
-class UnusedTrustProxies extends TrustProxies {}
+class UnusedTrustProxies extends TrustProxies
+{
+}


### PR DESCRIPTION
Fixes https://github.com/enlightn/enlightn/issues/48.

This PR fixes a bug where if we set the `$proxies` variable in our `TrustProxies` middleware, Enlightn would still mark it as unused.