### PR TITLE
Add ability to display exception stack trace of analyzers

### DIFF
--- a/src/Analyzers/Analyzer.php
+++ b/src/Analyzers/Analyzer.php
@@ -77,6 +77,13 @@ abstract class Analyzer
     protected $exceptionMessage = null;
 
     /**
+     * The stack trace of the exception thrown during the analysis.
+     *
+     * @var array
+     */
+    protected $stackTrace = null;
+
+    /**
      * Determine whether the analyzer passed.
      *
      * @var bool
@@ -173,6 +180,8 @@ abstract class Analyzer
     {
         $this->exceptionMessage = $e->getMessage();
 
+        $this->stackTrace = $e->getTraceAsString();
+
         return $this->markSkipped();
     }
 
@@ -232,6 +241,7 @@ abstract class Analyzer
             'docsUrl' => $this->getDocsUrl(),
             'reportable' => ! in_array(static::class, config('enlightn.dont_report', [])),
             'class' => static::class,
+            'stackTrace' => $this->stackTrace,
         ];
     }
 

--- a/src/Console/EnlightnCommand.php
+++ b/src/Console/EnlightnCommand.php
@@ -21,6 +21,7 @@ class EnlightnCommand extends Command
                             {--ci : Run Enlightn in CI Mode}
                             {--report : Compile a report to trigger a comment by the Enlightn Github Bot}
                             {--review : Enable this for a review of the diff by the Enlightn Github Bot}
+                            {--show-exceptions : Display the stack trace of exceptions if any}
                             {--issue= : The issue number of the pull request for the Enlightn Github Bot}';
 
     /**

--- a/src/Console/Formatters/AnsiFormatter.php
+++ b/src/Console/Formatters/AnsiFormatter.php
@@ -69,6 +69,10 @@ class AnsiFormatter implements Formatter
             $error = $result['error'] ?? $result['exception'];
             $command->line("<fg=red>{$error}</fg=red>");
 
+            if ($result['status'] === 'error' && $command->option('show-exceptions')) {
+                $command->line("<fg=red>{$result['stackTrace']}</fg=red>");
+            }
+
             if (! empty($result['traces'])) {
                 $this->formatTraces($command, $result['traces'], $allAnalyzers);
             }

--- a/tests/FaultyAnalyzer.php
+++ b/tests/FaultyAnalyzer.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Enlightn\Enlightn\Tests;
+
+use Enlightn\Enlightn\Analyzers\Performance\PerformanceAnalyzer;
+use RuntimeException;
+
+class FaultyAnalyzer extends PerformanceAnalyzer
+{
+    /**
+     * The title describing the analyzer.
+     *
+     * @var string|null
+     */
+    public $title = 'For testing purposes.';
+
+    /**
+     * The severity of the analyzer.
+     *
+     * @var string|null
+     */
+    public $severity = self::SEVERITY_MAJOR;
+
+    /**
+     * The time to fix in minutes.
+     *
+     * @var int|null
+     */
+    public $timeToFix = 10;
+
+    /**
+     * Execute the analyzer.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        throw new RuntimeException('Test exception thrown by faulty analyzer.');
+    }
+}


### PR DESCRIPTION
If an exception is thrown during an analyzer run, the Enlightn command used to just output the main message. This PR adds an option to display the stack trace as well to allow for easier debugging.