### PR TITLE
Add new analyzer to check for custom error pages

### DIFF
--- a/src/Analyzers/Reliability/CustomErrorPageAnalyzer.php
+++ b/src/Analyzers/Reliability/CustomErrorPageAnalyzer.php
@@ -2,10 +2,15 @@
 
 namespace Enlightn\Enlightn\Analyzers\Reliability;
 
+use Enlightn\Enlightn\Analyzers\Concerns\AnalyzesMiddleware;
+use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Routing\Router;
 
 class CustomErrorPageAnalyzer extends ReliabilityAnalyzer
 {
+    use AnalyzesMiddleware;
+
     /**
      * The title describing the analyzer.
      *
@@ -35,6 +40,19 @@ class CustomErrorPageAnalyzer extends ReliabilityAnalyzer
     public static $runInCI = false;
 
     /**
+     * Create a new analyzer instance.
+     *
+     * @param  \Illuminate\Routing\Router  $router
+     * @param  \Illuminate\Contracts\Http\Kernel  $kernel
+     * @return void
+     */
+    public function __construct(Router $router, Kernel $kernel)
+    {
+        $this->router = $router;
+        $this->kernel = $kernel;
+    }
+
+    /**
      * Get the error message describing the analyzer insights.
      *
      * @return string
@@ -60,5 +78,18 @@ class CustomErrorPageAnalyzer extends ReliabilityAnalyzer
         if (! $hasCustomErrorPages) {
             $this->markFailed();
         }
+    }
+
+    /**
+     * Determine whether to skip the analyzer.
+     *
+     * @return bool
+     * @throws \ReflectionException
+     */
+    public function skip()
+    {
+        // Skip this analyzer if the app is stateless. We assume here that if the app is stateless, it's probably not
+        // a web app and therefore, does not need to define any views.
+        return $this->appIsStateless();
     }
 }

--- a/src/Analyzers/Reliability/CustomErrorPageAnalyzer.php
+++ b/src/Analyzers/Reliability/CustomErrorPageAnalyzer.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Enlightn\Enlightn\Analyzers\Reliability;
+
+use Illuminate\Filesystem\Filesystem;
+
+class CustomErrorPageAnalyzer extends ReliabilityAnalyzer
+{
+    /**
+     * The title describing the analyzer.
+     *
+     * @var string|null
+     */
+    public $title = "Your application defines custom error page views.";
+
+    /**
+     * The severity of the analyzer.
+     *
+     * @var string|null
+     */
+    public $severity = self::SEVERITY_MINOR;
+
+    /**
+     * The time to fix in minutes.
+     *
+     * @var int|null
+     */
+    public $timeToFix = 60;
+
+    /**
+     * Determine whether the analyzer should be run in CI mode.
+     *
+     * @var bool
+     */
+    public static $runInCI = false;
+
+    /**
+     * Get the error message describing the analyzer insights.
+     *
+     * @return string
+     */
+    public function errorMessage()
+    {
+        return "Your application does not customize its error pages. This may hamper user experience and also exposes "
+            ."your application to fingerprinting, which means potential attackers can identify Laravel as your framework.";
+    }
+
+    /**
+     * Execute the analyzer.
+     *
+     * @param \Illuminate\Filesystem\Filesystem $files
+     * @return void
+     */
+    public function handle(Filesystem $files)
+    {
+        $hasCustomErrorPages = collect(config('view.paths'))->contains(function ($viewPath, $_) use ($files) {
+            return $files->exists($viewPath.DIRECTORY_SEPARATOR.'errors'.DIRECTORY_SEPARATOR.'404.blade.php');
+        });
+
+        if (! $hasCustomErrorPages) {
+            $this->markFailed();
+        }
+    }
+}

--- a/tests/Analyzers/Reliability/CustomErrorPageAnalyzerTest.php
+++ b/tests/Analyzers/Reliability/CustomErrorPageAnalyzerTest.php
@@ -4,9 +4,12 @@ namespace Enlightn\Enlightn\Tests\Analyzers\Reliability;
 
 use Enlightn\Enlightn\Analyzers\Reliability\CustomErrorPageAnalyzer;
 use Enlightn\Enlightn\Tests\Analyzers\AnalyzerTestCase;
+use Enlightn\Enlightn\Tests\Analyzers\Concerns\InteractsWithMiddleware;
 
 class CustomErrorPageAnalyzerTest extends AnalyzerTestCase
 {
+    use InteractsWithMiddleware;
+
     protected function getEnvironmentSetUp($app)
     {
         parent::getEnvironmentSetUp($app);
@@ -17,8 +20,20 @@ class CustomErrorPageAnalyzerTest extends AnalyzerTestCase
     /**
      * @test
      */
+    public function skipped_for_stateless_apps()
+    {
+        $this->runEnlightn();
+
+        $this->assertSkipped(CustomErrorPageAnalyzer::class);
+    }
+
+    /**
+     * @test
+     */
     public function detects_no_custom_error_pages()
     {
+        $this->registerStatefulGlobalMiddleware();
+
         $this->runEnlightn();
 
         $this->assertFailed(CustomErrorPageAnalyzer::class);
@@ -29,6 +44,7 @@ class CustomErrorPageAnalyzerTest extends AnalyzerTestCase
      */
     public function detects_custom_error_pages()
     {
+        $this->registerStatefulGlobalMiddleware();
         $this->app->config->set('view.paths', [$this->getViewStubPath()]);
 
         $this->runEnlightn();

--- a/tests/Analyzers/Reliability/CustomErrorPageAnalyzerTest.php
+++ b/tests/Analyzers/Reliability/CustomErrorPageAnalyzerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Enlightn\Enlightn\Tests\Analyzers\Reliability;
+
+use Enlightn\Enlightn\Analyzers\Reliability\CustomErrorPageAnalyzer;
+use Enlightn\Enlightn\Tests\Analyzers\AnalyzerTestCase;
+
+class CustomErrorPageAnalyzerTest extends AnalyzerTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $this->setupEnvironmentFor(CustomErrorPageAnalyzer::class, $app);
+    }
+
+    /**
+     * @test
+     */
+    public function detects_no_custom_error_pages()
+    {
+        $this->runEnlightn();
+
+        $this->assertFailed(CustomErrorPageAnalyzer::class);
+    }
+
+    /**
+     * @test
+     */
+    public function detects_custom_error_pages()
+    {
+        $this->app->config->set('view.paths', [$this->getViewStubPath()]);
+
+        $this->runEnlightn();
+
+        $this->assertPassed(CustomErrorPageAnalyzer::class);
+    }
+}

--- a/tests/Stubs/views/errors/404.blade.php
+++ b/tests/Stubs/views/errors/404.blade.php
@@ -1,0 +1,1 @@
+Some custom 404 page. Hello!


### PR DESCRIPTION
This PR adds a new analyzer to check for custom error pages. This has been intentionally left out from CI (even though it can run fine in CI environments) as it's really a good-to-have and shouldn't block CI pipelines.