### PR TITLE
Add json encoding for invalid credential warnings

### DIFF
--- a/src/Reporting/Client.php
+++ b/src/Reporting/Client.php
@@ -22,6 +22,7 @@ class Client
             'auth' => [$username, $apiToken],
             'timeout' => $timeout,
             'http_errors' => false,
+            'headers' => ['Accept' => 'application/json'],
         ]);
     }
 

--- a/tests/Analyzers/Security/VulnerableDependencyAnalyzerTest.php
+++ b/tests/Analyzers/Security/VulnerableDependencyAnalyzerTest.php
@@ -6,6 +6,8 @@ use Enlightn\Enlightn\Analyzers\Security\VulnerableDependencyAnalyzer;
 use Enlightn\Enlightn\Composer;
 use Enlightn\Enlightn\Tests\Analyzers\AnalyzerTestCase;
 use Enlightn\Enlightn\Tests\Analyzers\Concerns\InteractsWithComposer;
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Str;
 
 class VulnerableDependencyAnalyzerTest extends AnalyzerTestCase
 {
@@ -25,6 +27,11 @@ class VulnerableDependencyAnalyzerTest extends AnalyzerTestCase
      */
     public function confirms_enlightn_has_no_vulnerable_dependencies()
     {
+        if (Str::startsWith(Application::VERSION, '7')) {
+            // Since 7.x is no longer receiving security updates, we need to skip this version.
+            $this->markTestSkipped();
+        }
+
         $this->runEnlightn();
 
         $this->assertPassed(VulnerableDependencyAnalyzer::class);


### PR DESCRIPTION
Currently, the Enlightn terminal does not warn if the credentials are invalid. This is because the json accept encoding header is missing. This PR adds the header so that a warning can be displayed as show below.

![invalid-credentials](https://user-images.githubusercontent.com/16099046/116850425-46117180-ac0e-11eb-841a-19fc138cab62.png)
