### PR TITLE
Update version constraints to allow larastan and phpstan 1.0 - Fixes #87

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
         "guzzlehttp/guzzle": "^5.0|^6.0|^7.0",
         "laravel/framework": "^6.0|^7.0|^8.0",
         "nikic/php-parser": "^4.0",
-        "nunomaduro/larastan": "^0.6.11|^0.7",
-        "phpstan/phpstan": "^0.12.59",
+        "nunomaduro/larastan": "^0.6.11|^0.7|^1.0",
+        "phpstan/phpstan": "^0.12.59|^1.0",
         "enlightn/security-checker": "^1.1",
         "symfony/finder": "^4.0|^5.0"
     },


### PR DESCRIPTION
It does seem that this causes `Enlightn\Enlightn\Tests\Analyzers\Security\LicenseAnalyzerTest::confirms_enlightn_uses_dependencies_with_safe_licenses` to fail as `nette/schema` and `nette/utils` have `GLP-2.0-only` and `GPL-3.0-only` in their respective license chains.

This looks to have been fixed in #69, though.

```
﻿﻿nette/schema                          v1.2.2     BSD-3-Clause, GPL-2.0-only, GPL-3.0-only
nette/utils                           v3.2.5     BSD-3-Clause, GPL-2.0-only, GPL-3.0-only
```