### PR TITLE
fix: remove duplicate paths in ViewCachingAnalyzer

### DIFF
--- a/src/Analyzers/Performance/ViewCachingAnalyzer.php
+++ b/src/Analyzers/Performance/ViewCachingAnalyzer.php
@@ -93,6 +93,6 @@ class ViewCachingAnalyzer extends PerformanceAnalyzer
 
         return collect($finder->getPaths())->merge(
             collect($finder->getHints())->flatten()
-        );
+        )->unique();
     }
 }


### PR DESCRIPTION
Sometimes there is duplicated paths in function paths()