### PR TITLE
Support PHPStan and Larastan 1.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
         "guzzlehttp/guzzle": "^5.0|^6.0|^7.0",
         "laravel/framework": "^6.0|^7.0|^8.0",
         "nikic/php-parser": "^4.0",
-        "nunomaduro/larastan": "^0.6.11|^0.7",
-        "phpstan/phpstan": "^0.12.59",
+        "nunomaduro/larastan": "^0.6.11|^0.7|^1.0.0",
+        "phpstan/phpstan": "^0.12.59|>=1.0.0 <1.2.0",
         "enlightn/security-checker": "^1.1",
         "symfony/finder": "^4.0|^5.0"
     },


### PR DESCRIPTION
Closes #87 and #88

There are some BC breaks starting from PHPStan 1.2.x, so this PR adds PHPStan support upto 1.1.x