### PR TITLE
Add tests for PHP 8.1

### DIFF
--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.3, 7.4, 8.0]
+        php: [7.3, 7.4, 8.0, 8.1]
         laravel: [6.*, 7.*, 8.*]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,11 @@ jobs:
       matrix:
         php: [7.3, 7.4, 8.0, 8.1]
         laravel: [6.*, 7.*, 8.*]
+        exclude:
+          - php: 8.1
+            laravel: 6.*
+          - php: 8.1
+            laravel: 7.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.3, 7.4, 8.0]
+        php: [7.3, 7.4, 8.0, 8.1]
         laravel: [6.*, 7.*, 8.*]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 .php_cs
 .php_cs.cache
+.php-cs-fixer.cache
 .phpunit.result.cache
 build
 /composer.lock

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -4,15 +4,15 @@ $finder = PhpCsFixer\Finder::create()
     ->exclude('Stubs')
     ->in([__DIR__.'/src', __DIR__.'/tests', __DIR__.'/config']);
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setFinder($finder)
     ->setRules([
         '@PSR2' => true,
         'array_syntax' => ['syntax' => 'short'],
-        'ordered_imports' => ['sortAlgorithm' => 'alpha'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
         'no_unused_imports' => true,
         'not_operator_with_successor_space' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
         'phpdoc_scalar' => true,
         'unary_operator_spaces' => true,
         'binary_operator_spaces' => true,
@@ -23,7 +23,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_var_without_name' => true,
         'class_attributes_separation' => [
             'elements' => [
-                'method',
+                'method' => 'one',
             ],
         ],
         'method_argument_space' => [

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "barryvdh/laravel-ide-helper": "^2.8",
         "brianium/paratest": "^6.1",
         "fideloper/proxy": "^4.4",
-        "friendsofphp/php-cs-fixer": "^2.18",
+        "friendsofphp/php-cs-fixer": "^2.18|^3.0",
         "mockery/mockery": "^1.3",
         "orchestra/testbench": "^4.0|^5.0|^6.0",
         "phpunit/phpunit": "^7.5|^8.0|^9.0",


### PR DESCRIPTION
This PR adds PHP 8.1 to our Github test workflow and fixes the php CS fixer workflow.