### PR TITLE
Add support for Larastan 2.17+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "guzzlehttp/guzzle": "^7.0",
         "laravel/framework": "^9.0",
         "nikic/php-parser": "^4.0",
-        "nunomaduro/larastan": "^2.0 <= 2.1.6",
+        "nunomaduro/larastan": "^2.0",
         "phpstan/phpstan": "^1.4",
         "enlightn/security-checker": "^1.1",
         "symfony/finder": "^4.0|^5.0|^6.0"

--- a/src/PHPStan.php
+++ b/src/PHPStan.php
@@ -102,6 +102,11 @@ class PHPStan
      */
     public function start($paths, $configPath = null)
     {
+        if(file_exists($stubFile = collect([$this->rootPath, 'vendor' , 'nunomaduro', 'larastan', 'stubs', 'Http', 'Request.stub'])->join(DIRECTORY_SEPARATOR))) {
+            // Neither PHPStan nor Larastan supports stub overriding, so we have no choice but to overwrite the Request.stub file in the vendor/nunomaduro/larastan/stubs/Http directory
+            copy(collect([__DIR__, '..', 'stubs', 'Request.stub'])->join(DIRECTORY_SEPARATOR), $stubFile);
+        }
+
         $configPath = $configPath ?? $this->configPath ?? (__DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'phpstan.neon');
 
         $options = ['analyse', '--configuration='.$configPath, '--error-format=json', '--no-progress'];

--- a/src/PHPStan.php
+++ b/src/PHPStan.php
@@ -102,7 +102,7 @@ class PHPStan
      */
     public function start($paths, $configPath = null)
     {
-        if(file_exists($stubFile = collect([$this->rootPath, 'vendor' , 'nunomaduro', 'larastan', 'stubs', 'Http', 'Request.stub'])->join(DIRECTORY_SEPARATOR))) {
+        if (file_exists($stubFile = collect([$this->rootPath, 'vendor' , 'nunomaduro', 'larastan', 'stubs', 'Http', 'Request.stub'])->join(DIRECTORY_SEPARATOR))) {
             // Neither PHPStan nor Larastan supports stub overriding, so we have no choice but to overwrite the Request.stub file in the vendor/nunomaduro/larastan/stubs/Http directory
             copy(collect([__DIR__, '..', 'stubs', 'Request.stub'])->join(DIRECTORY_SEPARATOR), $stubFile);
         }


### PR DESCRIPTION
Not the best solution forward but since Larastan or PHPStan do not provide support for overriding stub files, this seems to be the only way.

Reference: https://github.com/nunomaduro/larastan/pull/1260#issuecomment-1152944828 and https://github.com/phpstan/phpstan/issues/7461