### PR TITLE
Inertia: check if the app renders custom error pages

### DIFF
--- a/src/Analyzers/Concerns/AnalyzesMiddleware.php
+++ b/src/Analyzers/Concerns/AnalyzesMiddleware.php
@@ -213,4 +213,15 @@ trait AnalyzesMiddleware
             }
         }
     }
+
+    /**
+     * Determine if the app uses Inertia.
+     *
+     * @return bool
+     * @throws \ReflectionException
+     */
+    protected function appUsesInertia()
+    {
+        return $this->appUsesMiddleware(\App\Http\Middleware\HandleInertiaRequests::class);
+    }
 }

--- a/src/Analyzers/Concerns/AnalyzesMiddleware.php
+++ b/src/Analyzers/Concerns/AnalyzesMiddleware.php
@@ -213,15 +213,4 @@ trait AnalyzesMiddleware
             }
         }
     }
-
-    /**
-     * Determine if the app uses Inertia.
-     *
-     * @return bool
-     * @throws \ReflectionException
-     */
-    protected function appUsesInertia()
-    {
-        return $this->appUsesMiddleware(\App\Http\Middleware\HandleInertiaRequests::class);
-    }
 }

--- a/src/Analyzers/Reliability/CustomErrorPageAnalyzer.php
+++ b/src/Analyzers/Reliability/CustomErrorPageAnalyzer.php
@@ -103,6 +103,4 @@ class CustomErrorPageAnalyzer extends ReliabilityAnalyzer
         // a web app and therefore, does not need to define any views.
         return $this->appIsStateless();
     }
-
- 
 }

--- a/src/Analyzers/Reliability/CustomErrorPageAnalyzer.php
+++ b/src/Analyzers/Reliability/CustomErrorPageAnalyzer.php
@@ -72,9 +72,7 @@ class CustomErrorPageAnalyzer extends ReliabilityAnalyzer
      */
     public function handle(Filesystem $files)
     {
-        $usesInertia = $this->appUsesMiddleware(\App\Http\Middleware\HandleInertiaRequests::class);
-
-        if ($usesInertia) {
+        if ($this->appUsesInertia()) {
             $handler = new ReflectionClass(app()->make(\App\Exceptions\Handler::class));
 
             if ($handler->hasMethod('render') && 
@@ -105,4 +103,6 @@ class CustomErrorPageAnalyzer extends ReliabilityAnalyzer
         // a web app and therefore, does not need to define any views.
         return $this->appIsStateless();
     }
+
+ 
 }


### PR DESCRIPTION
### TODO

- [x] Check if the app uses the Inertia middleware and if its overriding the default Exception render method
- [x] Write tests 

### Summary 

I want to check if the app uses the "Inertia way" of overriding the Laravel default error pages. I noticed that when overriding the default render method the result of checking the actual render method is different. This code:

```php
$handler = new ReflectionClass(app()->make(\App\Exceptions\Handler::class));
$className = $handler->getMethod('render')->getDeclaringClass()->getName();
dd($className);
```

Result when overriding the default render method:
`App\Exceptions\Handler`

Result when not overriding the default render method:
`Illuminate\Foundation\Exceptions\Handler`

So I decided to check if the actual render method is overridden. I’m not sure if this will be enough or that we also want/can check the content of the render method. 