### PR TITLE
[Feature Request]: Allowing to change memory_limit on the CLI

### DIFF
--- a/config/enlightn.php
+++ b/config/enlightn.php
@@ -169,4 +169,19 @@ return [
         storage_path(),
         app()->bootstrapPath('cache'),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | PHPStan Runtime configurations
+    |--------------------------------------------------------------------------
+    |
+    | PHPStan might fail on minimal memory_limit from php.ini.
+    | This allow us to pass different memory_limit into phpstan process object
+    | using `php -d memory_limit=1G artisan enlightn`.
+    */
+    'phpstan' => [
+        '--error-format' => 'json',
+        '--no-progress' => true,
+        '--memory-limit' => ini_get('memory_limit'),
+    ],
 ];

--- a/config/enlightn.php
+++ b/config/enlightn.php
@@ -175,8 +175,7 @@ return [
     | PHPStan Runtime configurations
     |--------------------------------------------------------------------------
     |
-    | PHPStan might fail on minimal memory_limit from php.ini.
-    | This allow us to pass different memory_limit into phpstan process object
+    | This setting allows us to pass through memory limits from artisan to phpstan.
     | using `php -d memory_limit=1G artisan enlightn`.
     */
     'phpstan' => [

--- a/src/PHPStan.php
+++ b/src/PHPStan.php
@@ -198,7 +198,7 @@ class PHPStan
     {
         $result = [];
 
-        $configs = config('enlightn.phpstan');
+        $configs = config('enlightn.phpstan', ['--error-format' => 'json', '--no-progress' => true]);
 
         foreach ($configs as $name => $value) {
             $option = is_bool($value) ? $name : implode('=', [$name, $value]);

--- a/src/PHPStan.php
+++ b/src/PHPStan.php
@@ -109,7 +109,9 @@ class PHPStan
 
         $configPath = $configPath ?? $this->configPath ?? (__DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'phpstan.neon');
 
-        $options = ['analyse', '--configuration='.$configPath, '--error-format=json', '--no-progress'];
+        $options = ['analyse', '--configuration='.$configPath];
+
+        $options = array_merge($options, $this->getPHPStanOptions());
 
         foreach (Arr::wrap($paths) as $path) {
             $options[] = $path;
@@ -185,5 +187,24 @@ class PHPStan
         $this->rootPath = realpath($path);
 
         return $this;
+    }
+
+    /**
+     * Get default PHPStan runtime configurations.
+     *
+     * @return array
+     */
+    protected function getPHPStanOptions()
+    {
+        $result = [];
+
+        $configs = config('enlightn.phpstan');
+
+        foreach ($configs as $name => $value) {
+            $option = is_bool($value) ? $name : implode('=', [$name, $value]);
+            array_push($result, $option);
+        }
+
+        return $result;
     }
 }


### PR DESCRIPTION
Using `enlightn` package within our development environment with default php container memory setup (aka 128M), phpstan kept crushing. 

Noticed that when the phpstan executes we cannot pass manually `--memory-limit` param to increase the memory capacity to let the script finish the execution.

I guess, it would be an easy option, to offload the predefined configurations we use in `start()` method into `config/enlightn.php`. Additionally, by setting the `--memory-limit` parameter there that is picked from the `ini_get()`, we can execute the following command, without changing `php.ini`:

```
php -d memory_limit=512M artisan enlightn
```