### PR TITLE
Make search for foreign `_id` fillables case-insensitive

### DIFF
--- a/src/PHPStan/FillableForeignKeyModelRule.php
+++ b/src/PHPStan/FillableForeignKeyModelRule.php
@@ -49,7 +49,7 @@ class FillableForeignKeyModelRule implements Rule
             }
 
             if ($item->value instanceof Node\Scalar\String_
-                && Str::contains($key = $item->value->value, '_id')) {
+                && Str::contains($key = $item->value->value, '_id', true)) {
                 return [
                     sprintf(
                         'Potential foreign key %s declared as fillable and available for mass assignment.',


### PR DESCRIPTION
Ensures any columns including `_ID`, `_Id`, etc. are also flagged when examining fillable foreign columns. In our legacy database's case, we use columns like `account_ID`. Enlightn was not picking up on these.

Like [the rule](https://www.laravel-enlightn.com/docs/security/fillable-foreign-key-analyzer.html) says: better safe than sorry!